### PR TITLE
Delete Clients/Apps/Messages when deleting a user

### DIFF
--- a/database/application.go
+++ b/database/application.go
@@ -31,6 +31,7 @@ func (d *GormDatabase) CreateApplication(application *model.Application) error {
 
 // DeleteApplicationByID deletes an application by its id.
 func (d *GormDatabase) DeleteApplicationByID(id uint) error {
+	d.DeleteMessagesByApplication(id)
 	return d.DB.Where("id = ?", id).Delete(&model.Application{}).Error
 }
 

--- a/database/application_test.go
+++ b/database/application_test.go
@@ -42,3 +42,21 @@ func (s *DatabaseSuite) TestApplication() {
 
 	assert.Nil(s.T(), s.db.GetApplicationByID(app.ID))
 }
+
+func (s *DatabaseSuite) TestDeleteAppDeletesMessages() {
+	s.db.CreateApplication(&model.Application{ID: 55, Token: "token"})
+	s.db.CreateApplication(&model.Application{ID: 66, Token: "token2"})
+	s.db.CreateMessage(&model.Message{ID: 12, ApplicationID: 55})
+	s.db.CreateMessage(&model.Message{ID: 13, ApplicationID: 66})
+	s.db.CreateMessage(&model.Message{ID: 14, ApplicationID: 55})
+	s.db.CreateMessage(&model.Message{ID: 15, ApplicationID: 55})
+
+	s.db.DeleteApplicationByID(55)
+
+	assert.Nil(s.T(), s.db.GetMessageByID(12))
+	assert.NotNil(s.T(), s.db.GetMessageByID(13))
+	assert.Nil(s.T(), s.db.GetMessageByID(14))
+	assert.Nil(s.T(), s.db.GetMessageByID(15))
+	assert.Empty(s.T(), s.db.GetMessagesByApplication(55))
+	assert.NotEmpty(s.T(), s.db.GetMessagesByApplication(66))
+}

--- a/database/user.go
+++ b/database/user.go
@@ -33,6 +33,12 @@ func (d *GormDatabase) GetUsers() []*model.User {
 
 // DeleteUserByID deletes a user by its id.
 func (d *GormDatabase) DeleteUserByID(id uint) error {
+	for _, app := range d.GetApplicationsByUser(id) {
+		d.DeleteApplicationByID(app.ID)
+	}
+	for _, client := range d.GetClientsByUser(id) {
+		d.DeleteClientByID(client.ID)
+	}
 	return d.DB.Where("id = ?", id).Delete(&model.User{}).Error
 }
 

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -45,3 +45,33 @@ func (s *DatabaseSuite) TestUser() {
 	users = s.db.GetUsers()
 	assert.Empty(s.T(), users)
 }
+
+func (s *DatabaseSuite) TestDeleteUserDeletesApplicationsAndClients() {
+	s.db.CreateUser(&model.User{Name: "nicories", ID: 10})
+	s.db.CreateApplication(&model.Application{ID: 100, Token: "apptoken", UserID: 10})
+	s.db.CreateMessage(&model.Message{ID: 1000, ApplicationID: 100})
+	s.db.CreateClient(&model.Client{ID: 10000, Token: "clienttoken", UserID: 10})
+
+	s.db.CreateUser(&model.User{Name: "nicories2", ID: 20})
+	s.db.CreateApplication(&model.Application{ID: 200, Token: "apptoken2", UserID: 20})
+	s.db.CreateMessage(&model.Message{ID: 2000, ApplicationID: 200})
+	s.db.CreateClient(&model.Client{ID: 20000, Token: "clienttoken2", UserID: 20})
+
+	s.db.DeleteUserByID(10)
+
+	assert.Nil(s.T(), s.db.GetApplicationByToken("apptoken"))
+	assert.Nil(s.T(), s.db.GetClientByToken("clienttoken"))
+	assert.Empty(s.T(), s.db.GetClientsByUser(10))
+	assert.Empty(s.T(), s.db.GetApplicationsByUser(10))
+	assert.Empty(s.T(), s.db.GetMessagesByApplication(100))
+	assert.Empty(s.T(), s.db.GetMessagesByUser(10))
+	assert.Nil(s.T(), s.db.GetMessageByID(1000))
+
+	assert.NotNil(s.T(), s.db.GetApplicationByToken("apptoken2"))
+	assert.NotNil(s.T(), s.db.GetClientByToken("clienttoken2"))
+	assert.NotEmpty(s.T(), s.db.GetClientsByUser(20))
+	assert.NotEmpty(s.T(), s.db.GetApplicationsByUser(20))
+	assert.NotEmpty(s.T(), s.db.GetMessagesByApplication(200))
+	assert.NotEmpty(s.T(), s.db.GetMessagesByUser(20))
+	assert.NotNil(s.T(), s.db.GetMessageByID(2000))
+}


### PR DESCRIPTION
sqlite3 doesn't support adding a foreign key via gorm.DB#AddForeignKey
this would mean, that we have some hacky solutions for having foreign
keys for sqlite and the other databases. Therefore manually deleting
the referencing models seems to be the best solution. We already have
interfaces for database capsuling, so no api must be adjusted.