### PR TITLE
Do not require a message title

### DIFF
--- a/api/message.go
+++ b/api/message.go
@@ -130,6 +130,10 @@ func (a *MessageAPI) CreateMessage(ctx *gin.Context) {
 	message := model.Message{}
 	if err := ctx.Bind(&message); err == nil {
 		message.ApplicationID = a.DB.GetApplicationByToken(auth.GetTokenID(ctx)).ID
+		// If no title was specified always use the application name
+		if len(message.Title) == 0 {
+			message.Title = a.DB.GetApplicationByToken(auth.GetTokenID(ctx)).Name
+		}
 		message.Date = timeNow()
 		a.DB.CreateMessage(&message)
 		a.Notifier.Notify(auth.GetUserID(ctx), &message)

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -1255,7 +1255,6 @@
         "id",
         "appid",
         "message",
-        "title",
         "date"
       ],
       "properties": {

--- a/model/message.go
+++ b/model/message.go
@@ -29,7 +29,7 @@ type Message struct {
 	//
 	// required: true
 	// example: Backup
-	Title string `form:"title" query:"title" json:"title" binding:"required"`
+	Title string `form:"title" query:"title" json:"title"`
 	// The priority of the message.
 	//
 	// example: 2


### PR DESCRIPTION
This commit makes the mandatory title field optional. If a message is
sent without a title, the application name will be used instead.

I've also started editing the tests for the necessary changes. I think those changes can also be part of this.