### PR TITLE
Update swagger doc. Add 400 BadRequest response in create and update endpoints

### DIFF
--- a/docs/spec.json
+++ b/docs/spec.json
@@ -110,6 +110,12 @@
               "$ref": "#/definitions/Application"
             }
           },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "schema": {
@@ -222,6 +228,12 @@
             "description": "Ok",
             "schema": {
               "$ref": "#/definitions/Application"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
             }
           },
           "401": {
@@ -443,6 +455,12 @@
               "$ref": "#/definitions/Client"
             }
           },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "schema": {
@@ -592,6 +610,12 @@
           "200": {
             "description": "Ok"
           },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "schema": {
@@ -704,6 +728,12 @@
             "description": "Ok",
             "schema": {
               "$ref": "#/definitions/Message"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
             }
           },
           "401": {
@@ -931,6 +961,12 @@
               "$ref": "#/definitions/User"
             }
           },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "schema": {
@@ -1046,6 +1082,12 @@
             "description": "Ok",
             "schema": {
               "$ref": "#/definitions/User"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/Error"
             }
           },
           "401": {


### PR DESCRIPTION
This code is related to this open issue https://github.com/gotify/server/issues/84

I don't see any update endpoint in the documentation and I only need to add the bad request error response code in creation endpoints.