### PR TITLE
support reverse proxy with path rewrite

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -101,7 +101,7 @@ func (a *ApplicationAPI) GetApplications(ctx *gin.Context) {
 	userID := auth.GetUserID(ctx)
 	apps := a.DB.GetApplicationsByUser(userID)
 	for _, app := range apps {
-		app = withResolvedImage(app)
+		withResolvedImage(app)
 	}
 	ctx.JSON(200, apps)
 }

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -130,7 +130,7 @@ func (s *ApplicationSuite) Test_CreateApplication_returnsApplicationWithID() {
 		ID:     1,
 		Token:  firstApplicationToken,
 		Name:   "custom_name",
-		Image:  "http://example.com/static/defaultapp.png",
+		Image:  "static/defaultapp.png",
 		UserID: 5,
 	}
 	assert.Equal(s.T(), 200, s.recorder.Code)
@@ -162,8 +162,8 @@ func (s *ApplicationSuite) Test_GetApplications() {
 	s.a.GetApplications(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
-	first.Image = "http://example.com/static/defaultapp.png"
-	second.Image = "http://example.com/static/defaultapp.png"
+	first.Image = "static/defaultapp.png"
+	second.Image = "static/defaultapp.png"
 	test.BodyEquals(s.T(), []*model.Application{first, second}, s.recorder)
 }
 
@@ -180,8 +180,8 @@ func (s *ApplicationSuite) Test_GetApplications_WithImage() {
 	s.a.GetApplications(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
-	first.Image = "http://example.com/image/abcd.jpg"
-	second.Image = "http://example.com/static/defaultapp.png"
+	first.Image = "image/abcd.jpg"
+	second.Image = "static/defaultapp.png"
 	test.BodyEquals(s.T(), []*model.Application{first, second}, s.recorder)
 }
 

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -1804,7 +1804,7 @@
           "type": "string",
           "x-go-name": "Image",
           "readOnly": true,
-          "example": "https://example.com/image.jpeg"
+          "example": "image/image.jpeg"
         },
         "internal": {
           "description": "Whether the application is an internal application. Internal applications should not be deleted.",

--- a/docs/swagger.go
+++ b/docs/swagger.go
@@ -10,11 +10,14 @@ import (
 
 // Serve serves the documentation.
 func Serve(ctx *gin.Context) {
-	url := location.Get(ctx)
-	ctx.Writer.WriteString(get(url.Host))
+	base := location.Get(ctx).Host
+	if bQ := ctx.Query("base"); bQ != "" {
+		base = bQ
+	}
+	ctx.Writer.WriteString(get(base))
 }
 
-func get(host string) string {
+func get(base string) string {
 	box := packr.NewBox("./")
-	return strings.Replace(box.String("spec.json"), "localhost", host, 1)
+	return strings.Replace(box.String("spec.json"), "localhost", base, 1)
 }

--- a/docs/swagger.go
+++ b/docs/swagger.go
@@ -11,8 +11,8 @@ import (
 // Serve serves the documentation.
 func Serve(ctx *gin.Context) {
 	base := location.Get(ctx).Host
-	if bQ := ctx.Query("base"); bQ != "" {
-		base = bQ
+	if basePathFromQuery := ctx.Query("base"); basePathFromQuery != "" {
+		base = basePathFromQuery
 	}
 	ctx.Writer.WriteString(get(base))
 }

--- a/docs/swagger_test.go
+++ b/docs/swagger_test.go
@@ -16,12 +16,13 @@ func TestServe(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(recorder)
 	withURL(ctx, "http", "example.com")
 
-	ctx.Request = httptest.NewRequest("GET", "/swagger", nil)
+	ctx.Request = httptest.NewRequest("GET", "/swagger?base="+url.QueryEscape("127.0.0.1/proxy/"), nil)
 
 	Serve(ctx)
 
 	content := recorder.Body.String()
 	assert.NotEmpty(t, content)
+	assert.Contains(t, content, "127.0.0.1/proxy/")
 }
 
 func withURL(ctx *gin.Context, scheme, host string) {

--- a/docs/ui.go
+++ b/docs/ui.go
@@ -39,10 +39,15 @@ var ui = `
     <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.20.5/swagger-ui-bundle.js"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.20.5/swagger-ui-standalone-preset.js"> </script>
     <script>
+    function getBaseURL() {
+      var path = window.location.pathname
+      path = path.substr(0, path.lastIndexOf('/')+1)
+      return window.location.host + path;
+    }
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "../swagger",
+        url: "swagger?base="+encodeURIComponent(getBaseURL()),
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/model/application.go
+++ b/model/application.go
@@ -39,7 +39,7 @@ type Application struct {
 	//
 	// read only: true
 	// required: true
-	// example: https://example.com/image.jpeg
+	// example: image/image.jpeg
 	Image    string            `json:"image"`
 	Messages []MessageExternal `json:"-"`
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,7 @@
   "name": "gotify-ui",
   "version": "0.2.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@material-ui/core": "^1.5.1",
     "@material-ui/icons": "^2.0.3",

--- a/ui/src/application/Applications.tsx
+++ b/ui/src/application/Applications.tsx
@@ -18,6 +18,7 @@ import AddApplicationDialog from './AddApplicationDialog';
 import {observer} from 'mobx-react';
 import {observable} from 'mobx';
 import {inject, Stores} from '../inject';
+import * as config from '../config';
 import UpdateDialog from './UpdateApplicationDialog';
 
 @observer
@@ -152,7 +153,7 @@ const Row: SFC<IRowProps> = observer(
         <TableRow>
             <TableCell padding="checkbox">
                 <div style={{display: 'flex'}}>
-                    <Avatar src={image} />
+                    <Avatar src={config.get('url') + image} />
                     <IconButton onClick={fUpload} style={{height: 40}}>
                         <CloudUpload />
                     </IconButton>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -21,9 +21,10 @@ const defaultDevConfig = {
     url: 'http://localhost:80/',
 };
 
-const {port, hostname, protocol} = window.location;
+const {port, hostname, protocol, pathname} = window.location;
 const slashes = protocol.concat('//');
-const url = slashes.concat(port ? hostname.concat(':', port) : hostname);
+const path = pathname.endsWith('/') ? pathname : pathname.substring(0, pathname.lastIndexOf('/'));
+const url = slashes.concat(port ? hostname.concat(':', port) : hostname) + path;
 const urlWithSlash = url.endsWith('/') ? url : url.concat('/');
 
 const defaultProdConfig = {

--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -5,6 +5,7 @@ import Delete from '@material-ui/icons/Delete';
 import React from 'react';
 import TimeAgo from 'react-timeago';
 import Container from '../common/Container';
+import * as config from '../config';
 import {StyleRulesCallback} from '@material-ui/core/styles/withStyles';
 
 const styles: StyleRulesCallback = () => ({
@@ -57,7 +58,7 @@ class Message extends React.PureComponent<IProps & WithStyles<typeof styles>> {
                 <Container style={{display: 'flex'}}>
                     <div className={classes.imageWrapper}>
                         <img
-                            src={image}
+                            src={config.get('url') + image}
                             alt="app logo"
                             width="70"
                             height="70"


### PR DESCRIPTION
This fixes #122.

Changed the home path so that the page loads static assets relative to the page URL.

Also changed how API path is parsed so that the base path is considered.