### PR TITLE
Log web socket errors

### DIFF
--- a/api/stream/stream.go
+++ b/api/stream/stream.go
@@ -129,6 +129,7 @@ func (a *API) register(client *client) {
 func (a *API) Handle(ctx *gin.Context) {
 	conn, err := a.upgrader.Upgrade(ctx.Writer, ctx.Request, nil)
 	if err != nil {
+		ctx.Error(err)
 		return
 	}
 


### PR DESCRIPTION
Adds logging like this:
```
[GIN] 2019/03/06 - 20:28:19 | 400 |     211.498µs |      172.18.0.1 | GET      /stream?token=CRO8zhuUfIyn2hE
Error #01: websocket: the client is not using the websocket protocol: 'upgrade' token not found in 'Connection' header
```