### PR TITLE
Fix websocket allowed origin

### DIFF
--- a/api/stream/stream.go
+++ b/api/stream/stream.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -165,12 +166,12 @@ func isAllowedOrigin(r *http.Request, allowedOrigins []*regexp.Regexp) bool {
 		return false
 	}
 
-	if u.Hostname() == r.Host {
+	if strings.ToLower(u.Host) == strings.ToLower(r.Host) {
 		return true
 	}
 
 	for _, allowedOrigin := range allowedOrigins {
-		if allowedOrigin.Match([]byte(u.Hostname())) {
+		if allowedOrigin.Match([]byte(strings.ToLower(u.Hostname()))) {
 			return true
 		}
 	}

--- a/api/stream/stream.go
+++ b/api/stream/stream.go
@@ -156,12 +156,12 @@ func (a *API) Close() {
 }
 
 func isAllowedOrigin(r *http.Request, allowedOrigins []*regexp.Regexp) bool {
-	origin := r.Header["Origin"]
-	if len(origin) == 0 {
+	origin := r.Header.Get("origin")
+	if origin == "" {
 		return true
 	}
 
-	u, err := url.Parse(origin[0])
+	u, err := url.Parse(origin)
 	if err != nil {
 		return false
 	}

--- a/api/stream/stream_test.go
+++ b/api/stream/stream_test.go
@@ -408,6 +408,14 @@ func Test_sameOrigin_returnsTrue(t *testing.T) {
 	assert.True(t, actual)
 }
 
+func Test_sameOrigin_returnsTrue_withCustomPort(t *testing.T) {
+	mode.Set(mode.Prod)
+	req := httptest.NewRequest("GET", "http://example.com:8080/stream", nil)
+	req.Header.Set("Origin", "http://example.com:8080")
+	actual := isAllowedOrigin(req, nil)
+	assert.True(t, actual)
+}
+
 func Test_isAllowedOrigin_withoutAllowedOrigins_failsWhenNotSameOrigin(t *testing.T) {
 	mode.Set(mode.Prod)
 	req := httptest.NewRequest("GET", "http://example.com/stream", nil)


### PR DESCRIPTION
This fixes #149.

See the original issue for description. The main problem for the original implementation is comparing hostname and a `host:port`