### PR TITLE
Add armv7 docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,17 @@ package-zip: extract-licenses
        zip -ur $$BUILD.zip ${LICENSE_DIR}; \
     done
 
-build-docker: require-version
+build-docker-amd64: require-version
 	cp ${BUILD_DIR}/gotify-linux-amd64 ./docker/gotify-app
 	(cd ${DOCKER_DIR} && docker build -t gotify/server:latest -t gotify/server:${VERSION} .)
 	rm ${DOCKER_DIR}gotify-app
+
+build-docker-arm-7: require-version
+	cp ${BUILD_DIR}/gotify-linux-arm-7 ./docker/gotify-app
+	(cd ${DOCKER_DIR} && docker build -f Dockerfile.armv7 -t gotify/server-arm7:latest -t gotify/server-arm7:${VERSION} .)
+	rm ${DOCKER_DIR}gotify-app
+
+build-docker: build-docker-amd64 build-docker-arm-7
 
 build-js:
 	(cd ui && yarn build)

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -2,3 +2,4 @@
 
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
 docker push gotify/server
+docker push gotify/server-arm7

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,0 +1,4 @@
+FROM arm32v7/debian
+WORKDIR /app
+ADD gotify-app /app/
+ENTRYPOINT ["./gotify-app"]


### PR DESCRIPTION
Fixes #218 

Tested it with a raspberry pi 3 b+  on arch
```
[root@alarmpi ~]# uname -a
Linux alarmpi 4.19.65-1-ARCH #1 SMP PREEMPT Fri Aug 9 23:29:04 UTC 2019 armv7l GNU/Linux
[root@alarmpi ~]# docker run --rm jmattheis/test:coolnewtest
Starting Gotify version unknown@unknown
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /                         --> github.com/gotify/server/ui.serveFile.func1 (6 handlers)
[GIN-debug] GET    /index.html               --> github.com/gotify/server/ui.serveFile.func1 (6 handlers)
[GIN-debug] GET    /manifest.json            --> github.com/gotify/server/ui.serveFile.func1 (6 handlers)
```