### PR TITLE
Allow to send message to specifics clients in an app

### DIFF
--- a/api/message.go
+++ b/api/message.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gotify/location"
@@ -388,6 +387,9 @@ func toInternalMessage(msg *model.MessageExternal) *model.Message {
 	if msg.Extras != nil {
 		res.Extras, _ = json.Marshal(msg.Extras)
 	}
+	if msg.Clients!=nil{
+		res.Clients,_ =  json.Marshal(msg.Clients)
+	}
 	return res
 }
 
@@ -403,6 +405,10 @@ func toExternalMessage(msg *model.Message) *model.MessageExternal {
 	if len(msg.Extras) != 0 {
 		res.Extras = make(map[string]interface{})
 		json.Unmarshal(msg.Extras, &res.Extras)
+	}
+	if len(msg.Clients) != 0 {
+		res.Clients = []string{}
+		json.Unmarshal(msg.Clients, &res.Clients)
 	}
 	return res
 }

--- a/api/stream/stream.go
+++ b/api/stream/stream.go
@@ -62,7 +62,7 @@ func (a *API) NotifyDeletedClient(userID uint, token string) {
 				clients = append(clients[:i], clients[i+1:]...)
 			}
 		}*/
-		if cliente,okey := clients[token]; okey{
+		if client, ok := clients[token]; ok {
 			cliente.Close()
 			delete(clients,token)
 		}

--- a/model/message.go
+++ b/model/message.go
@@ -13,6 +13,7 @@ type Message struct {
 	Priority      int
 	Extras        []byte
 	Date          time.Time
+	Clients       []byte
 }
 
 // MessageExternal Model
@@ -62,4 +63,11 @@ type MessageExternal struct {
 	// required: true
 	// example: 2018-02-27T19:36:10.5045044+01:00
 	Date time.Time `json:"date"`
+	// The tokens of the clients.
+	//
+	// read only: true
+	// required: false
+	// example: ["token1","token2","token3"]
+	// if empty, the message is sent to all clients
+	Clients[] string `form:"clients[]" query:"-" json:"clients"`
 }


### PR DESCRIPTION
Now, You can send messages like:

curl -X POST "https://push.example.de/message?token=<app_token>" -F "title=my title" -F "message=my message" -F "priority=5" -F "clients[]=<clienttoken_1>"  -F "clients[]=<clienttoken_2>"  -F "clients[]=<clienttoken_n>"

And the messages will only be sent to those clients.

If you do not specify the tokens, the message will be sent to all the clients, like the normal behavior

