### PR TITLE
Auto reconnect on connection loss

### DIFF
--- a/ui/src/CurrentUser.ts
+++ b/ui/src/CurrentUser.ts
@@ -127,7 +127,7 @@ export class CurrentUser {
             .then(() => this.snack('Password changed'));
     };
 
-    public tryReconnect = (quiet: boolean = false) => {
+    public tryReconnect = (quiet = false) => {
         this.tryAuthenticate().catch(() => {
             if (!quiet) {
                 this.snack('Reconnect failed');

--- a/ui/src/CurrentUser.ts
+++ b/ui/src/CurrentUser.ts
@@ -127,7 +127,7 @@ export class CurrentUser {
             .then(() => this.snack('Password changed'));
     };
 
-    public tryReconnect = (quiet = false) => {
+    public tryReconnect = (quiet: boolean = false) => {
         this.tryAuthenticate().catch(() => {
             if (!quiet) {
                 this.snack('Reconnect failed');

--- a/ui/src/common/NetworkLostBanner.tsx
+++ b/ui/src/common/NetworkLostBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
@@ -8,14 +8,6 @@ interface NetworkLostBannerProps {
 }
 
 export const NetworkLostBanner = ({height, retry}: NetworkLostBannerProps) => {
-    useEffect(() => {
-        const intervalId = setInterval(retry, 3000);
-            
-        return() => {
-                clearInterval(intervalId);
-            }
-        });
-
     return (
         <div
             style={{
@@ -33,5 +25,4 @@ export const NetworkLostBanner = ({height, retry}: NetworkLostBannerProps) => {
             </Typography>
         </div>
     );
-
 };

--- a/ui/src/common/NetworkLostBanner.tsx
+++ b/ui/src/common/NetworkLostBanner.tsx
@@ -9,9 +9,9 @@ interface NetworkLostBannerProps {
 
 export const NetworkLostBanner = ({height, retry}: NetworkLostBannerProps) => {
     useEffect(() => {
-            var intervalId = setInterval(retry, 3000);
+        const intervalId = setInterval(retry, 3000);
             
-            return() => {
+        return() => {
                 clearInterval(intervalId);
             }
         });

--- a/ui/src/common/NetworkLostBanner.tsx
+++ b/ui/src/common/NetworkLostBanner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
@@ -8,6 +8,14 @@ interface NetworkLostBannerProps {
 }
 
 export const NetworkLostBanner = ({height, retry}: NetworkLostBannerProps) => {
+    useEffect(() => {
+            var intervalId = setInterval(retry, 3000);
+            
+            return() => {
+                clearInterval(intervalId);
+            }
+        });
+
     return (
         <div
             style={{
@@ -25,4 +33,5 @@ export const NetworkLostBanner = ({height, retry}: NetworkLostBannerProps) => {
             </Typography>
         </div>
     );
+
 };

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -98,7 +98,7 @@ class Layout extends React.Component<
             <MuiThemeProvider theme={theme}>
                 <HashRouter>
                     <div>
-                        {hasNetwork ? null : <NetworkLostBanner height={64} retry={tryReconnect} />}
+                        {hasNetwork ? null : <NetworkLostBanner height={64} retry={() => tryReconnect()} />}
                         <div style={{display: 'flex'}}>
                             <CssBaseline />
                             <Header

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -63,8 +63,6 @@ class Layout extends React.Component<
     private showSettings = false;
     @observable
     private version = Layout.defaultVersion;
-    @observable
-    private reconnecting = false;
 
     public componentDidMount() {
         if (this.version === Layout.defaultVersion) {
@@ -81,19 +79,6 @@ class Layout extends React.Component<
         }
     }
 
-    private doReconnect = () => {
-        this.reconnecting = true;
-        this.props.currentUser
-            .tryAuthenticate()
-            .then(() => {
-                this.reconnecting = false;
-            })
-            .catch(() => {
-                this.reconnecting = false;
-                this.props.snackManager.snack('Reconnect failed');
-            });
-    };
-
     public render() {
         const {version, showSettings, currentTheme} = this;
         const {
@@ -104,6 +89,7 @@ class Layout extends React.Component<
                 user: {name, admin},
                 logout,
                 hasNetwork,
+                tryReconnect,
             },
         } = this.props;
         const theme = themeMap[currentTheme];
@@ -112,9 +98,7 @@ class Layout extends React.Component<
             <MuiThemeProvider theme={theme}>
                 <HashRouter>
                     <div>
-                        {hasNetwork ? null : (
-                            <NetworkLostBanner height={64} retry={this.doReconnect} />
-                        )}
+                        {hasNetwork ? null : <NetworkLostBanner height={64} retry={tryReconnect} />}
                         <div style={{display: 'flex'}}>
                             <CssBaseline />
                             <Header
@@ -131,7 +115,7 @@ class Layout extends React.Component<
 
                             <main className={classes.content}>
                                 <Switch>
-                                    {authenticating || this.reconnecting ? (
+                                    {authenticating ? (
                                         <Route path="/">
                                             <LoadingSpinner />
                                         </Route>

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -98,7 +98,9 @@ class Layout extends React.Component<
             <MuiThemeProvider theme={theme}>
                 <HashRouter>
                     <div>
-                        {hasNetwork ? null : <NetworkLostBanner height={64} retry={() => tryReconnect()} />}
+                        {hasNetwork ? null : (
+                            <NetworkLostBanner height={64} retry={() => tryReconnect()} />
+                        )}
                         <div style={{display: 'flex'}}>
                             <CssBaseline />
                             <Header


### PR DESCRIPTION
I've used react hooks to add a side effect into `NetworkLostBanner` component.

The function sets a timer (in `componentDidMount`) that every 3 seconds tries to call the `retry` function. When the component is unmounted, the `clearInterval` is called (in `componentWillUnmount`) to cancel the timed action.

This fix improve server to manage connection loss status (see #226).

Fixes #226 