### PR TITLE
Added major.minor tagging to docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,20 @@ package-zip: extract-licenses
 
 build-docker-amd64: require-version
 	cp ${BUILD_DIR}/gotify-linux-amd64 ./docker/gotify-app
-	(cd ${DOCKER_DIR} && docker build -t gotify/server:latest -t gotify/server:${VERSION} -t gotify/server:$(shell echo $(VERSION) | cut -d '.' -f -2) .)
+	cd ${DOCKER_DIR} && \
+		docker build \
+		-t gotify/server:latest \
+		-t gotify/server:${VERSION} \
+		-t gotify/server:$(shell echo $(VERSION) | cut -d '.' -f -2) .
 	rm ${DOCKER_DIR}gotify-app
 
 build-docker-arm-7: require-version
 	cp ${BUILD_DIR}/gotify-linux-arm-7 ./docker/gotify-app
-	(cd ${DOCKER_DIR} && docker build -f Dockerfile.armv7 -t gotify/server-arm7:latest -t gotify/server-arm7:${VERSION} -t gotify/server-arm7:$(shell echo $(VERSION) | cut -d '.' -f -2) .)
+	cd ${DOCKER_DIR} && \
+		docker build -f Dockerfile.armv7 \
+		-t gotify/server-arm7:latest \
+		-t gotify/server-arm7:${VERSION} \
+		-t gotify/server-arm7:$(shell echo $(VERSION) | cut -d '.' -f -2) .
 	rm ${DOCKER_DIR}gotify-app
 
 build-docker: build-docker-amd64 build-docker-arm-7

--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,12 @@ package-zip: extract-licenses
 
 build-docker-amd64: require-version
 	cp ${BUILD_DIR}/gotify-linux-amd64 ./docker/gotify-app
-	(cd ${DOCKER_DIR} && docker build -t gotify/server:latest -t gotify/server:${VERSION} .)
+	(cd ${DOCKER_DIR} && docker build -t gotify/server:latest -t gotify/server:${VERSION} -t gotify/server:$(shell echo $(VERSION) | cut -d '.' -f -2) .)
 	rm ${DOCKER_DIR}gotify-app
 
 build-docker-arm-7: require-version
 	cp ${BUILD_DIR}/gotify-linux-arm-7 ./docker/gotify-app
-	(cd ${DOCKER_DIR} && docker build -f Dockerfile.armv7 -t gotify/server-arm7:latest -t gotify/server-arm7:${VERSION} .)
+	(cd ${DOCKER_DIR} && docker build -f Dockerfile.armv7 -t gotify/server-arm7:latest -t gotify/server-arm7:${VERSION} -t gotify/server-arm7:$(shell echo $(VERSION) | cut -d '.' -f -2) .)
 	rm ${DOCKER_DIR}gotify-app
 
 build-docker: build-docker-amd64 build-docker-arm-7


### PR DESCRIPTION
I've added an extra tag to the docker images that tags the docker images with `major.minor` in addition to the current tags. i.e it now does `2.0` in addition to `2.0.9` and `latest`.

Fixes issue #219 