### PR TITLE
Fix websocket reconnect logic

### DIFF
--- a/ui/src/message/WebSocketStore.ts
+++ b/ui/src/message/WebSocketStore.ts
@@ -36,10 +36,6 @@ export class WebSocketStore {
             this.wsActive = false;
             this.currentUser
                 .tryAuthenticate()
-                .then(() => {
-                    this.snack('WebSocket connection closed, trying again in 30 seconds.');
-                    setTimeout(this.listen, 30000);
-                })
                 .catch((error: AxiosError) => {
                     if (error && error.response && error.response.status === 401) {
                         this.snack('Could not authenticate with client token, logging out.');

--- a/ui/src/message/WebSocketStore.ts
+++ b/ui/src/message/WebSocketStore.ts
@@ -34,11 +34,17 @@ export class WebSocketStore {
 
         ws.onclose = () => {
             this.wsActive = false;
-            this.currentUser.tryAuthenticate().catch((error: AxiosError) => {
-                if (error && error.response && error.response.status === 401) {
-                    this.snack('Could not authenticate with client token, logging out.');
-                }
-            });
+            this.currentUser
+                .tryAuthenticate()
+                .then(() => {
+                    this.snack('WebSocket connection closed, trying again in 30 seconds.');
+                    setTimeout(() => this.listen(callback), 30000);
+                })
+                .catch((error: AxiosError) => {
+                    if (error && error.response && error.response.status === 401) {
+                        this.snack('Could not authenticate with client token, logging out.');
+                    }
+                });
         };
 
         this.ws = ws;

--- a/ui/src/message/WebSocketStore.ts
+++ b/ui/src/message/WebSocketStore.ts
@@ -34,13 +34,11 @@ export class WebSocketStore {
 
         ws.onclose = () => {
             this.wsActive = false;
-            this.currentUser
-                .tryAuthenticate()
-                .catch((error: AxiosError) => {
-                    if (error && error.response && error.response.status === 401) {
-                        this.snack('Could not authenticate with client token, logging out.');
-                    }
-                });
+            this.currentUser.tryAuthenticate().catch((error: AxiosError) => {
+                if (error && error.response && error.response.status === 401) {
+                    this.snack('Could not authenticate with client token, logging out.');
+                }
+            });
         };
 
         this.ws = ws;


### PR DESCRIPTION
The code is obsolete now that there is the improved auto reconnect function

It also did never actually work anyway. [This](https://github.com/gotify/server/blob/master/ui/src/message/WebSocketStore.ts#L41) will call `listen` with an undefined callback, thus leading to the following error and effectively preventing the client from reconnecting automatically.

`TypeError: e is not a function WebSocketStore.ts:33:33`