### PR TITLE
Fix #247: Long word/URL escapes it's parent box in the WebUI

### DIFF
--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -36,6 +36,7 @@ const styles = (): StyleRules => ({
     },
     content: {
         whiteSpace: 'pre-wrap',
+        wordBreak: 'break-all',
         '& p': {
             margin: 0,
         },


### PR DESCRIPTION
Fix https://github.com/gotify/server/issues/247 by adding
```
word-break: break-all;
```

I have tested the behaviour in local build and it seems to be working ok:

![Screenshot_2019-12-14 Gotify(1)](https://user-images.githubusercontent.com/42121756/70849642-bb499e80-1e81-11ea-9056-057490547f06.png)
