### PR TITLE
Expose port 80 by default in the Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:glibc-2.28
 WORKDIR /app
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates
 ADD gotify-app /app/
 EXPOSE 80
 ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,4 +2,5 @@ FROM frolvlad/alpine-glibc:glibc-2.28
 WORKDIR /app
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 ADD gotify-app /app/
+EXPOSE 80
 ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,4 +1,5 @@
 FROM arm32v7/debian
 WORKDIR /app
 ADD gotify-app /app/
+EXPOSE 80
 ENTRYPOINT ["./gotify-app"]


### PR DESCRIPTION
Fixes #251. Adds the `EXPOSE 80` directive to both the `amd64` and `armv7` Dockerfiles enabling seamless usage with [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy). Also makes the `ca-cerificates` installation line more readable.