### PR TITLE
Reduce ping interval

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -26,7 +26,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	g.Use(gin.Logger(), gin.Recovery(), error.Handler(), location.Default())
 	g.NoRoute(error.NotFound())
 
-	streamHandler := stream.New(200*time.Second, 15*time.Second, conf.Server.Stream.AllowedOrigins)
+	streamHandler := stream.New(45*time.Second, 15*time.Second, conf.Server.Stream.AllowedOrigins)
 	authentication := auth.Auth{DB: db}
 	messageHandler := api.MessageAPI{Notifier: streamHandler, DB: db}
 	healthHandler := api.HealthAPI{DB: db}


### PR DESCRIPTION
Some reverse proxies have default timeouts of 60 seconds after they
close the websocket connetion.

Fixes #245