### PR TITLE
Skip /etc/gotify/config.yml in tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gotify/configor"
+	"github.com/gotify/server/mode"
 )
 
 // Configuration is stuff that can be configured externally per env variables or config file (config.yml).
@@ -44,10 +45,17 @@ type Configuration struct {
 	PluginsDir        string `default:"data/plugins"`
 }
 
+func configFiles() []string {
+	if mode.Get() == mode.TestDev {
+		return []string{"config.yml"}
+	}
+	return []string{"config.yml", "/etc/gotify/config.yml"}
+}
+
 // Get returns the configuration extracted from env variables or config file.
 func Get() *Configuration {
 	conf := new(Configuration)
-	err := configor.New(&configor.Config{EnvironmentPrefix: "GOTIFY"}).Load(conf, "config.yml", "/etc/gotify/config.yml")
+	err := configor.New(&configor.Config{EnvironmentPrefix: "GOTIFY"}).Load(conf, configFiles()...)
 	if err != nil {
 		panic(err)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gotify/server/mode"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigEnv(t *testing.T) {
+	mode.Set(mode.TestDev)
 	os.Setenv("GOTIFY_DEFAULTUSER_NAME", "jmattheis")
 	os.Setenv("GOTIFY_SERVER_SSL_LETSENCRYPT_HOSTS", "- push.example.tld\n- push.other.tld")
 	os.Setenv("GOTIFY_SERVER_RESPONSEHEADERS",
@@ -31,6 +33,7 @@ func TestConfigEnv(t *testing.T) {
 }
 
 func TestAddSlash(t *testing.T) {
+	mode.Set(mode.TestDev)
 	os.Setenv("GOTIFY_UPLOADEDIMAGESDIR", "../data/images")
 	conf := Get()
 	assert.Equal(t, "../data/images"+string(filepath.Separator), conf.UploadedImagesDir)
@@ -38,6 +41,7 @@ func TestAddSlash(t *testing.T) {
 }
 
 func TestNotAddSlash(t *testing.T) {
+	mode.Set(mode.TestDev)
 	os.Setenv("GOTIFY_UPLOADEDIMAGESDIR", "../data/")
 	conf := Get()
 	assert.Equal(t, "../data/", conf.UploadedImagesDir)
@@ -45,6 +49,7 @@ func TestNotAddSlash(t *testing.T) {
 }
 
 func TestFileWithSyntaxErrors(t *testing.T) {
+	mode.Set(mode.TestDev)
 	file, err := os.Create("config.yml")
 	defer func() {
 		file.Close()
@@ -63,6 +68,7 @@ sdgsgsdfgsdfg
 }
 
 func TestConfigFile(t *testing.T) {
+	mode.Set(mode.TestDev)
 	file, err := os.Create("config.yml")
 	defer func() {
 		file.Close()


### PR DESCRIPTION
Our config test ensures that the correct values will be extracted from
the config file and environment variables.
A globally defined config may change settings which are expected to have
default values.

See
https://github.com/gotify/server-aur-git/pull/2#issuecomment-597598574