### PR TITLE
 Open github link in new tab

### DIFF
--- a/ui/src/layout/Header.tsx
+++ b/ui/src/layout/Header.tsx
@@ -118,7 +118,11 @@ class Header extends Component<IProps> {
                             <Highlight />
                         </IconButton>
 
-                        <a href="https://github.com/gotify/server" className={classes.link} target="_blank" rel="noopener noreferrer">
+                        <a
+                            href="https://github.com/gotify/server"
+                            className={classes.link}
+                            target="_blank"
+                            rel="noopener noreferrer">
                             <IconButton color="inherit">
                                 <GitHubIcon />
                             </IconButton>

--- a/ui/src/layout/Header.tsx
+++ b/ui/src/layout/Header.tsx
@@ -118,7 +118,7 @@ class Header extends Component<IProps> {
                             <Highlight />
                         </IconButton>
 
-                        <a href="https://github.com/gotify/server" className={classes.link} target="_blank" rel="noopener">
+                        <a href="https://github.com/gotify/server" className={classes.link} target="_blank" rel="noopener noreferrer">
                             <IconButton color="inherit">
                                 <GitHubIcon />
                             </IconButton>

--- a/ui/src/layout/Header.tsx
+++ b/ui/src/layout/Header.tsx
@@ -118,7 +118,7 @@ class Header extends Component<IProps> {
                             <Highlight />
                         </IconButton>
 
-                        <a href="https://github.com/gotify/server" className={classes.link}>
+                        <a href="https://github.com/gotify/server" className={classes.link} target="_blank" rel="noopener">
                             <IconButton color="inherit">
                                 <GitHubIcon />
                             </IconButton>


### PR DESCRIPTION
Added target="_blank" and rel="noopener" to github icon in the upper right corner to open in a new tab.

Fixes #275