### PR TITLE
Run as non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,18 @@
 FROM frolvlad/alpine-glibc:glibc-2.28
+
+ENV GID 999
+ENV UID 999
+
 WORKDIR /app
-RUN apk add --no-cache ca-certificates tzdata
-ADD gotify-app /app/
-EXPOSE 80
+
+RUN addgroup -g ${GID} -S gotify && \
+    adduser -u ${UID} -S gotify -G gotify && \
+    apk add --no-cache ca-certificates tzdata
+
+COPY --chown=gotify:gotify gotify-app /app/
+
+EXPOSE 8080
+
 ENTRYPOINT ["./gotify-app"]
+
+USER gotify


### PR DESCRIPTION
Run application with a non-root user.

Environment variables for `group` and `user` can be customized in e.g. `docker-compose.yml`:

```sh
version: '3.8'

services:
  app:
    image: gotify/server:2.0
    volumes:
      - ./data:/app/data
    environment:
      - GID=999
      - UID=999
```

If running as non-root user, the privileged port `80` can't be used, therefore was changed to `8080`.

File owner of existing files in data mounts needs to be updated as well.

Resolves #306.