### PR TITLE
Support custom ports in Docker healthcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ check-go:
 	go vet ./...
 	gocyclo -over 10 $(shell find . -iname '*.go' -type f | grep -v /vendor/)
 	golint -set_exit_status $(shell go list ./... | grep -v mock)
-	goimports -l $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+	goimports -l $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./packrd/*")
 
 check-js:
 	(cd ui && yarn lint)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM frolvlad/alpine-glibc:glibc-2.31
+ENV GOTIFY_SERVER_PORT="80"
 WORKDIR /app
 RUN apk add --no-cache ca-certificates tzdata curl
 ADD gotify-app /app/
-HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:80/health || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
 EXPOSE 80
 ENTRYPOINT ["./gotify-app"]


### PR DESCRIPTION
Currently, the Docker container running with a custom port will always be shown unhealthy. This fix introduces a default port, which is overwritten when a user specifies a custom environment variable via Docker.

Please verify again that this works. I had to test a downstripped version, because my Podman didn't like it as is.