### PR TITLE
Allow delete for > uint32 ids

### DIFF
--- a/api/internalutil.go
+++ b/api/internalutil.go
@@ -2,13 +2,14 @@ package api
 
 import (
 	"errors"
+	"math/bits"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
 
 func withID(ctx *gin.Context, name string, f func(id uint)) {
-	if id, err := strconv.ParseUint(ctx.Param(name), 10, 32); err == nil {
+	if id, err := strconv.ParseUint(ctx.Param(name), 10, bits.UintSize); err == nil {
 		f(uint(id))
 	} else {
 		ctx.AbortWithError(400, errors.New("invalid id"))


### PR DESCRIPTION
For ids uint is used, this is platform specific and either uint32
or uint64. The parsing for parameters in the api expected the ids to
have 32bit size.

I thought about changing all our ids to int64 but we sadly have one uint
usage in the plugin api:
https://github.com/gotify/plugin-api/blob/b0e2eca8e35526b0c02fdb5e2179a92bb8cb457f/plugin.go#L13-L14