### PR TITLE
Add arm64 docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,16 @@ build-docker-arm-7: require-version
 		-t gotify/server-arm7:$(shell echo $(VERSION) | cut -d '.' -f -2) .
 	rm ${DOCKER_DIR}gotify-app
 
-build-docker: build-docker-amd64 build-docker-arm-7
+build-docker-arm64: require-version
+	cp ${BUILD_DIR}/gotify-linux-arm64 ./docker/gotify-app
+	cd ${DOCKER_DIR} && \
+		docker build -f Dockerfile.arm64 \
+		-t gotify/server-arm64:latest \
+		-t gotify/server-arm64:${VERSION} \
+		-t gotify/server-arm64:$(shell echo $(VERSION) | cut -d '.' -f -2) .
+	rm ${DOCKER_DIR}gotify-app
+
+build-docker: build-docker-amd64 build-docker-arm-7 build-docker-arm64
 
 build-js:
 	(cd ui && yarn build)

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,5 @@
+FROM arm64v8/debian
+WORKDIR /app
+ADD gotify-app /app/
+EXPOSE 80
+ENTRYPOINT ["./gotify-app"]


### PR DESCRIPTION
this PR adds building an arm64 docker image to the build.

its related to https://github.com/gotify/server/issues/257 and solves the issue at least for arm64.