### PR TITLE
fix: download-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ check-js:
 	(cd ui && yarn testformat)
 
 download-tools:
-	GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger
+	go get -u github.com/go-swagger/go-swagger/cmd/swagger
 
 embed-static:
 	go run hack/packr/packr.go


### PR DESCRIPTION
The download-tools command on Makefile fails with:

```
make download-tools
GO111MODULE=off go get -u github.com/go-swagger/go-swagger/cmd/swagger
cannot find package "github.com/hashicorp/hcl/hcl/printer" in any of:
	/opt/hostedtoolcache/go/1.15.8/x64/src/github.com/hashicorp/hcl/hcl/printer (from $GOROOT)
	/home/runner/go/src/github.com/hashicorp/hcl/hcl/printer (from $GOPATH)
Makefile:41: recipe for target 'download-tools' failed
make: *** [download-tools] Error 1
```

Removing the GO111MODULE=off fixes this.