### PR TITLE
[UI] Fix message image width to not exceed width of parent container

### DIFF
--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -60,6 +60,10 @@ const styles = (theme: Theme) =>
             '& pre': {
                 overflow: 'auto',
             },
+            '& img': {
+                maxWidth: '100%',
+            },
+       
         },
     });
 

--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -63,7 +63,6 @@ const styles = (theme: Theme) =>
             '& img': {
                 maxWidth: '100%',
             },
-       
         },
     });
 


### PR DESCRIPTION
This adds a `max-width` to a message image, so that it does not go off the screen in the web UI. This is purely a cosmetic change in the web client's styling.

Fixes #259 