### PR TITLE
Update the ARM Dockerfiles to align with the default Dockerfile

### DIFF
--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,5 +1,12 @@
 FROM arm64v8/debian
+ENV GOTIFY_SERVER_PORT="80"
 WORKDIR /app
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq \
+  tzdata \
+  curl \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 ADD gotify-app /app/
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
 EXPOSE 80
 ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,5 +1,12 @@
 FROM arm32v7/debian:stable-slim
+ENV GOTIFY_SERVER_PORT="80"
 WORKDIR /app
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq \
+  tzdata \
+  curl \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 ADD gotify-app /app/
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
 EXPOSE 80
 ENTRYPOINT ["./gotify-app"]


### PR DESCRIPTION
I wanted to add a `HEALTHCHECK` to the Dockerfile and noticed there already is one for the default file but not for the ARM variants. I copied the directives in the default file over so they're all consistent.