### PR TITLE
Implement service worker for offline notifications

### DIFF
--- a/ui/public/static/notification-worker.js
+++ b/ui/public/static/notification-worker.js
@@ -25,11 +25,37 @@ self.addEventListener("activate", () => {
     const ws = new WebSocket(`${wsProto}//${host}/stream?token=${gotifyKey}`)
     console.log("Notification worker connected to websocket, waiting for messages")
 
-    ws.onmessage = function(event) {
-        msgObj = JSON.parse(event.data)
-        self.registration.showNotification("WORKER: " + msgObj.title, {
-            body: msgObj.message
+    ws.onmessage = (event) => {
+
+        // check if any client is currently visible
+        // if so, skip sending notification from worker
+        self.clients.matchAll({
+            type: "window",
+            includeUncontrolled: true
         })
+            .then((windowClients) => {
+                var clientVisible = false
+                for (var i = 0; i < windowClients.length; i++) {
+                    const windowClient = windowClients[i]
+                    // check if a client is visible, then break
+                    if (windowClient.visibilityState === "visible") {
+                        clientVisible = true
+                        break
+                    }
+                }
+                return clientVisible
+            }) // use the bool to evaluate whether to send a notification 
+            .then((clientVisible) => {
+                if (!clientVisible) {
+                    var msgObj = JSON.parse(event.data) // parse event data, only if not visible
+                    self.registration.showNotification("WORKER: " + msgObj.title, {
+                        body: msgObj.message
+                    })
+                } else {
+                    console.log("not sending worker notification, as gotify window is visible")
+                }
+            })
+
     }
 
 })

--- a/ui/public/static/notification-worker.js
+++ b/ui/public/static/notification-worker.js
@@ -27,7 +27,9 @@ self.addEventListener("activate", () => {
 
     ws.onmessage = function(event) {
         msgObj = JSON.parse(event.data)
-        self.registration.showNotification("WORKER: " + msgObj.message)
+        self.registration.showNotification("WORKER: " + msgObj.title, {
+            body: msgObj.message
+        })
     }
 
 })

--- a/ui/public/static/notification-worker.js
+++ b/ui/public/static/notification-worker.js
@@ -1,0 +1,33 @@
+var gotifyKey = undefined
+
+self.addEventListener("install", event => {
+    event.waitUntil(new Promise((resolve, reject) => {
+        try {
+            // resolves install promise only if search param 'key' was provided
+            gotifyKey = new URL(location).searchParams.get('key');
+        } catch (e) {
+            reject(e)
+        }
+        if (!gotifyKey) {
+            reject("gotify-login-key not provided")
+        }
+        console.log("Worker recieved gotify-login-key, successfully installed")
+        resolve()
+    }))
+})
+
+self.addEventListener("activate", () => {
+
+    console.log("Notification worker activated")
+
+    const host = location.host
+    const wsProto = location.protocol === "https:" ? "wss:" : "ws:"
+    const ws = new WebSocket(`${wsProto}//${host}/stream?token=${gotifyKey}`)
+    console.log("Notification worker connected to websocket, waiting for messages")
+
+    ws.onmessage = function(event) {
+        msgObj = JSON.parse(event.data)
+        self.registration.showNotification("WORKER: " + msgObj.message)
+    }
+
+})

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -61,7 +61,12 @@ const initStores = (): StoreMapping => {
 
     registerReactions(stores);
 
-    stores.currentUser.tryAuthenticate().catch(() => {});
+    stores.currentUser.tryAuthenticate().then(() => {
+        // always request notification permission when logged in
+        Notification.requestPermission()
+            .then(perm => console.log("Notification permissions " + perm))
+            .catch(console.error)
+    }).catch(() => {});
 
     window.onbeforeunload = () => {
         stores.wsStore.close();

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -4,7 +4,7 @@ import 'typeface-roboto';
 import {initAxios} from './apiAuth';
 import * as config from './config';
 import Layout from './layout/Layout';
-import {unregister} from './registerServiceWorker';
+import {registerNotificationWorker} from './registerServiceWorker';
 import {CurrentUser} from './CurrentUser';
 import {AppStore} from './application/AppStore';
 import {WebSocketStore} from './message/WebSocketStore';
@@ -66,6 +66,8 @@ const initStores = (): StoreMapping => {
         Notification.requestPermission()
             .then(perm => console.log("Notification permissions " + perm))
             .catch(console.error)
+        // reregister worker
+        registerNotificationWorker(stores.currentUser.token());
     }).catch(() => {});
 
     window.onbeforeunload = () => {
@@ -78,5 +80,5 @@ const initStores = (): StoreMapping => {
         </InjectProvider>,
         document.getElementById('root')
     );
-    unregister();
+    //unregister();
 })();

--- a/ui/src/registerServiceWorker.ts
+++ b/ui/src/registerServiceWorker.ts
@@ -5,3 +5,43 @@ export function unregister() {
         });
     }
 }
+
+export function registerNotificationWorker(key: string) {
+    if ('serviceWorker' in navigator) {
+        // provide the gotify-login-key as query parameter, as the service worker cannot access
+        // localStorage. There is no need to implement a mechanism to update the key as the
+        // worker will be unregistered on logout.
+        navigator.serviceWorker.register("static/notification-worker.js?key=" + key, {
+            scope: "/static/notification-worker"
+        })
+            .then((r) => {
+                // request notification permission
+                Notification.requestPermission()
+                    .then(perm => console.log("Notification permissions " + perm))
+                    .catch(console.error)
+                return r
+            })
+            .catch(console.error)
+    } else {
+        console.error("Service workers are not supported in your browser!")
+    }
+}
+
+export function unregisterNotificationWorker() {
+    if ('serviceWorker' in navigator) {
+        // get service worker by scope
+        navigator.serviceWorker.getRegistration("/static/notification-worker").then((reg) => {
+            if (reg) {
+                reg.unregister().then(ok => { // ok: bool === true, if unregister was successfull
+                    if (!ok) {
+                        console.error("Error unregistering service worker")
+                    }
+                })
+            } else {
+                console.error("Error finding service worker by scope")
+            }
+        })
+    } else {
+        console.error("Service workers are not supported in your browser!")
+    }
+}

--- a/ui/src/registerServiceWorker.ts
+++ b/ui/src/registerServiceWorker.ts
@@ -14,13 +14,6 @@ export function registerNotificationWorker(key: string) {
         navigator.serviceWorker.register("static/notification-worker.js?key=" + key, {
             scope: "/static/notification-worker"
         })
-            .then((r) => {
-                // request notification permission
-                Notification.requestPermission()
-                    .then(perm => console.log("Notification permissions " + perm))
-                    .catch(console.error)
-                return r
-            })
             .catch(console.error)
     } else {
         console.error("Service workers are not supported in your browser!")


### PR DESCRIPTION
**This is a draft**

Fixes #344 

### How does it work
After logging in, a new service worker is created. The `gotify-login-key` gets passed to it via query parameter so that it can subscribe to the Websocket `/stream` endpoint. On incoming messages, it creates a notification. This way, no third party server must be used (e.g. a vendor server for the Webpush API).

The worker keeps running until the user logs out and the client is removed. It keeps running when the browser is closed.

It also seems like notifications work on android from within the browser now, as android only supports notifications via Service Worker ([source](https://web.dev/push-notifications/#are-service-workers-involved)).

(When testing, do not forget applying [this workaround](https://stackoverflow.com/a/54934302) when not testing over HTTPS or `localhost`.)

### Todos
- [x] Currently, when the UI is open, you get two notifications - one from the UI and one from the worker
- [x] Worker notification sound (?)
- [ ] Stability testing (does the worker really persist? How about browser or OS restarts?)

Please add your changes if necessary. I've kept the `console.log` statements for easier testing. They need to be removed before merging, of course.