### PR TITLE
Adds intermediate struct to handle application creation/update params

### DIFF
--- a/api/application_test.go
+++ b/api/application_test.go
@@ -112,7 +112,7 @@ func (s *ApplicationSuite) Test_CreateApplication_ignoresReadOnlyPropertiesInPar
 	s.db.User(5)
 
 	test.WithUser(s.ctx, 5)
-	s.withJson(&model.Application{
+	s.withJSON(&model.Application{
 		Name:        "name",
 		Description: "description",
 		ID:          333,
@@ -123,7 +123,7 @@ func (s *ApplicationSuite) Test_CreateApplication_ignoresReadOnlyPropertiesInPar
 
 	s.a.CreateApplication(s.ctx)
 
-	expectedJsonValue, _ := json.Marshal(&model.Application{
+	expectedJSONValue, _ := json.Marshal(&model.Application{
 		ID:          1,
 		Token:       firstApplicationToken,
 		UserID:      5,
@@ -134,7 +134,7 @@ func (s *ApplicationSuite) Test_CreateApplication_ignoresReadOnlyPropertiesInPar
 	})
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
-	assert.Equal(s.T(), string(expectedJsonValue), string(s.recorder.Body.Bytes()))
+	assert.Equal(s.T(), string(expectedJSONValue), s.recorder.Body.String())
 }
 
 func (s *ApplicationSuite) Test_DeleteApplication_expectNotFoundOnCurrentUserIsNotOwner() {
@@ -535,7 +535,7 @@ func (s *ApplicationSuite) withFormData(formData string) {
 	s.ctx.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 }
 
-func (s *ApplicationSuite) withJson(value interface{}) {
+func (s *ApplicationSuite) withJSON(value interface{}) {
 	jsonVal, _ := json.Marshal(value)
 	s.ctx.Request = httptest.NewRequest("POST", "/application", bytes.NewBuffer(jsonVal))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -105,6 +106,35 @@ func (s *ApplicationSuite) Test_CreateApplication_expectBadRequestOnEmptyName() 
 	if app, err := s.db.GetApplicationsByUser(5); assert.NoError(s.T(), err) {
 		assert.Empty(s.T(), app)
 	}
+}
+
+func (s *ApplicationSuite) Test_CreateApplication_ignoresReadOnlyPropertiesInParams() {
+	s.db.User(5)
+
+	test.WithUser(s.ctx, 5)
+	s.withJson(&model.Application{
+		Name:        "name",
+		Description: "description",
+		ID:          333,
+		Internal:    true,
+		Token:       "token",
+		Image:       "adfdf",
+	})
+
+	s.a.CreateApplication(s.ctx)
+
+	expectedJsonValue, _ := json.Marshal(&model.Application{
+		ID:          1,
+		Token:       firstApplicationToken,
+		UserID:      5,
+		Name:        "name",
+		Description: "description",
+		Internal:    false,
+		Image:       "static/defaultapp.png",
+	})
+
+	assert.Equal(s.T(), 200, s.recorder.Code)
+	assert.Equal(s.T(), string(expectedJsonValue), string(s.recorder.Body.Bytes()))
 }
 
 func (s *ApplicationSuite) Test_DeleteApplication_expectNotFoundOnCurrentUserIsNotOwner() {
@@ -503,6 +533,12 @@ func (s *ApplicationSuite) Test_UpdateApplication_WithoutPermission_expectNotFou
 func (s *ApplicationSuite) withFormData(formData string) {
 	s.ctx.Request = httptest.NewRequest("POST", "/token", strings.NewReader(formData))
 	s.ctx.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+}
+
+func (s *ApplicationSuite) withJson(value interface{}) {
+	jsonVal, _ := json.Marshal(value)
+	s.ctx.Request = httptest.NewRequest("POST", "/application", bytes.NewBuffer(jsonVal))
+	s.ctx.Request.Header.Set("Content-Type", "application/json")
 }
 
 // A modified version of https://stackoverflow.com/a/20397167/4244993 from Attila O.

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -99,7 +99,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Application"
+              "$ref": "#/definitions/ApplicationParams"
             }
           }
         ],
@@ -162,7 +162,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Application"
+              "$ref": "#/definitions/ApplicationParams"
             }
           },
           {
@@ -1913,7 +1913,7 @@
         "id": {
           "description": "The application id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 5
@@ -1948,6 +1948,29 @@
       },
       "x-go-package": "github.com/gotify/server/v2/model"
     },
+    "ApplicationParams": {
+      "description": "Params allowed to create or update Applications",
+      "type": "object",
+      "title": "Application Params Model",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "description": {
+          "description": "The description of the application.",
+          "type": "string",
+          "x-go-name": "Description",
+          "example": "Backup server for the interwebs"
+        },
+        "name": {
+          "description": "The application name. This is how the application should be displayed to the user.",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "Backup Server"
+        }
+      },
+      "x-go-package": "github.com/gotify/server/v2/api"
+    },
     "Client": {
       "description": "The Client holds information about a device which can receive notifications (and other stuff).",
       "type": "object",
@@ -1961,7 +1984,7 @@
         "id": {
           "description": "The client id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 5
@@ -2052,7 +2075,7 @@
         "appid": {
           "description": "The application id that send this message.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ApplicationID",
           "readOnly": true,
           "example": 5
@@ -2084,7 +2107,7 @@
         "id": {
           "description": "The message id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2166,7 +2189,7 @@
         "since": {
           "description": "The ID of the last message returned in the current request. Use this as alternative to the next link.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "minimum": 0,
           "x-go-name": "Since",
           "readOnly": true,
@@ -2224,7 +2247,7 @@
         "id": {
           "description": "The plugin id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2285,7 +2308,7 @@
         "id": {
           "description": "The user id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2337,7 +2360,7 @@
         "id": {
           "description": "The user id.",
           "type": "integer",
-          "format": "int64",
+          "format": "uint64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -1913,7 +1913,7 @@
         "id": {
           "description": "The application id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 5
@@ -1984,7 +1984,7 @@
         "id": {
           "description": "The client id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 5
@@ -2075,7 +2075,7 @@
         "appid": {
           "description": "The application id that send this message.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ApplicationID",
           "readOnly": true,
           "example": 5
@@ -2107,7 +2107,7 @@
         "id": {
           "description": "The message id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2189,7 +2189,7 @@
         "since": {
           "description": "The ID of the last message returned in the current request. Use this as alternative to the next link.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "minimum": 0,
           "x-go-name": "Since",
           "readOnly": true,
@@ -2247,7 +2247,7 @@
         "id": {
           "description": "The plugin id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2308,7 +2308,7 @@
         "id": {
           "description": "The user id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25
@@ -2360,7 +2360,7 @@
         "id": {
           "description": "The user id.",
           "type": "integer",
-          "format": "uint64",
+          "format": "int64",
           "x-go-name": "ID",
           "readOnly": true,
           "example": 25


### PR DESCRIPTION
https://github.com/gotify/server/issues/466

An intermediate struct was added to handle params used in creation and update controllers preventing the edition of fields that are `readOnly` .

