### PR TITLE
Adds ClientParams strcut to handle creation and update params

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -76,6 +76,21 @@ func (s *ClientSuite) Test_CreateClient_mapAllParameters() {
 	}
 }
 
+func (s *ClientSuite) Test_CreateClient_ignoresReadOnlyPropertiesInParams() {
+	s.db.User(5)
+	test.WithUser(s.ctx, 5)
+
+	s.withFormData("name=myclient&ID=45&Token=12341234&UserID=333")
+
+	s.a.CreateClient(s.ctx)
+	expected := &model.Client{ID: 1, UserID: 5, Token: firstClientToken, Name: "myclient"}
+
+	assert.Equal(s.T(), 200, s.recorder.Code)
+	if clients, err := s.db.GetClientsByUser(5); assert.NoError(s.T(), err) {
+		assert.Contains(s.T(), clients, expected)
+	}
+}
+
 func (s *ClientSuite) Test_CreateClient_expectBadRequestOnEmptyName() {
 	s.db.User(5)
 

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -599,7 +599,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Client"
+              "$ref": "#/definitions/ClientParams"
             }
           }
         ],
@@ -665,7 +665,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Client"
+              "$ref": "#/definitions/ClientParams"
             }
           },
           {
@@ -2091,6 +2091,23 @@
         }
       },
       "x-go-package": "github.com/gotify/server/v2/model"
+    },
+    "ClientParams": {
+      "description": "Params allowed to create or update Clients",
+      "type": "object",
+      "title": "Client Params Model",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "The client name",
+          "type": "string",
+          "x-go-name": "Name",
+          "example": "My Client"
+        }
+      },
+      "x-go-package": "github.com/gotify/server/v2/api"
     },
     "CreateUserExternal": {
       "description": "Used for user creation.",


### PR DESCRIPTION
https://github.com/gotify/server/issues/466

An intermediate struct was added to handle params used in creation and update client controllers preventing the edition of fields that are readOnly.