### PR TITLE
log: filter requests to /health from localhost

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -176,6 +176,10 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 var tokenRegexp = regexp.MustCompile("token=[^&]+")
 
 func logFormatter(param gin.LogFormatterParams) string {
+	if param.ClientIP == "127.0.0.1" && param.Path == "/health" {
+		return ""
+	}
+
 	var statusColor, methodColor, resetColor string
 	if param.IsOutputColor() {
 		statusColor = param.StatusCodeColor()


### PR DESCRIPTION
fixes #428 

I have tested it and it works perfectly. Returning an empty string will not print an empty line, but doesn't output a line at all. I added the if block at the top so that it's an early exit without unnecessary processing if a match occurs.