### PR TITLE
[WIP] add option for extended logging

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -191,8 +191,8 @@ func logFormatter(param gin.LogFormatterParams) string {
 		param.Latency = param.Latency - param.Latency%time.Second
 	}
 	path := tokenRegexp.ReplaceAllString(param.Path, "token=[masked]")
-	return fmt.Sprintf("[GIN] %v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
-		param.TimeStamp.Format("2006/01/02 - 15:04:05"),
+	return fmt.Sprintf("%v |%s %3d %s| %13v | %15s |%s %-7s %s %#v\n%s",
+		param.TimeStamp.Format(time.RFC3339),
 		statusColor, param.StatusCode, resetColor,
 		param.Latency,
 		param.ClientIP,


### PR DESCRIPTION
I believe there is a bug in the config code.

As soon as there is a default value defined in the struct, env vars seem to be ignored.

I have added a debug output for you to see the problem:

```
$ export GOTIFY_EXTENDEDLOGFORMAT=false
$ ./gotify-server
init() ExtendedLogFormat = true
Starting Gotify version 2.2.4-4-g62a1c99@2023-05-23-17:37:16
Started Listening for plain HTTP connection on :80
```

If you remove the default `default:"true"` in `config/config.go`, it works. (It will heed the value of `GOTIFY_EXTENDEDLOGFORMAT`.)

I have marked this PR as work in progress, since I ran into this little problem and because you haven't decided whether you want to add this yet.

However, please let me stress this again: a TZ info is rather important. I am pretty sure that most system admins will agree. The "`[GIN] `" text is also not very useful.
You also mentioned using a standard format like Apache/nginx. I have to say that the default Apache or NCSA log format does not use a proper date format. Your log looks actually quite nice. The pipe symbols are perfectly valid field separators, because they are not part of any of the fields' potential values.

Fixes #565 