### PR TITLE
add API endpoint to remove an app's image

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -409,11 +409,12 @@ func (a *ApplicationAPI) RemoveApplicationImage(ctx *gin.Context) {
 				return
 			}
 
+			image := app.Image
 			app.Image = ""
 			if success := successOrAbort(ctx, 500, a.DB.UpdateApplication(app)); !success {
 				return
 			}
-			os.Remove(a.ImageDir + app.Image)
+			os.Remove(a.ImageDir + image)
 			ctx.JSON(200, withResolvedImage(app))
 		} else {
 			ctx.AbortWithError(404, fmt.Errorf("app with id %d doesn't exists", id))

--- a/api/application.go
+++ b/api/application.go
@@ -358,6 +358,69 @@ func (a *ApplicationAPI) UploadApplicationImage(ctx *gin.Context) {
 	})
 }
 
+// RemoveApplicationImage deletes an image of an application.
+// swagger:operation DELETE /application/{id}/image application removeAppImage
+//
+// Deletes an image of an application.
+//
+// ---
+// consumes: [application/json]
+// produces: [application/json]
+// parameters:
+// - name: id
+//   in: path
+//   description: the application id
+//   required: true
+//   type: integer
+//   format: int64
+// security: [clientTokenAuthorizationHeader: [], clientTokenHeader: [], clientTokenQuery: [], basicAuth: []]
+// responses:
+//   200:
+//     description: Ok
+//   400:
+//     description: Bad Request
+//     schema:
+//         $ref: "#/definitions/Error"
+//   401:
+//     description: Unauthorized
+//     schema:
+//         $ref: "#/definitions/Error"
+//   403:
+//     description: Forbidden
+//     schema:
+//         $ref: "#/definitions/Error"
+//   404:
+//     description: Not Found
+//     schema:
+//         $ref: "#/definitions/Error"
+//   500:
+//     description: Server Error
+//     schema:
+//         $ref: "#/definitions/Error"
+func (a *ApplicationAPI) RemoveApplicationImage(ctx *gin.Context) {
+	withID(ctx, "id", func(id uint) {
+		app, err := a.DB.GetApplicationByID(id)
+		if success := successOrAbort(ctx, 500, err); !success {
+			return
+		}
+		if app != nil && app.UserID == auth.GetUserID(ctx) {
+			if app.Image == "" {
+				ctx.AbortWithError(400, fmt.Errorf("app with id %d does not have a customized image", id))
+				return
+			}
+
+			app.Image = ""
+			if success := successOrAbort(ctx, 500, a.DB.UpdateApplication(app)); !success {
+				return
+			}
+			os.Remove(a.ImageDir + app.Image)
+			ctx.JSON(200, withResolvedImage(app))
+		} else {
+			ctx.AbortWithError(404, fmt.Errorf("app with id %d doesn't exists", id))
+		}
+	})
+}
+
 func withResolvedImage(app *model.Application) *model.Application {
 	if app.Image == "" {
 		app.Image = "static/defaultapp.png"

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -426,6 +426,43 @@ func (s *ApplicationSuite) Test_UploadAppImage_expectNotFound() {
 	assert.Equal(s.T(), 404, s.recorder.Code)
 }
 
+func (s *ApplicationSuite) Test_RemoveAppImage_expectNotFound() {
+	s.db.User(5)
+
+	test.WithUser(s.ctx, 5)
+	s.ctx.Request = httptest.NewRequest("DELETE", "/irrelevant", nil)
+	s.ctx.Params = gin.Params{{Key: "id", Value: "4"}}
+
+	s.a.RemoveApplicationImage(s.ctx)
+
+	assert.Equal(s.T(), 404, s.recorder.Code)
+}
+
+func (s *ApplicationSuite) Test_RemoveAppImage_noCustomizedImage() {
+	s.db.User(5).App(1)
+
+	test.WithUser(s.ctx, 5)
+	s.ctx.Request = httptest.NewRequest("DELETE", "/irrelevant", nil)
+	s.ctx.Params = gin.Params{{Key: "id", Value: "1"}}
+	s.a.RemoveApplicationImage(s.ctx)
+
+	assert.Equal(s.T(), 400, s.recorder.Code)
+}
+
+func (s *ApplicationSuite) Test_RemoveAppImage_expectSuccess() {
+	s.db.User(5)
+
+	s.db.CreateApplication(&model.Application{UserID: 5, ID: 1, Image: "existing.png"})
+	fakeImage(s.T(), "existing.png")
+
+	test.WithUser(s.ctx, 5)
+	s.ctx.Request = httptest.NewRequest("DELETE", "/irrelevant", nil)
+	s.ctx.Params = gin.Params{{Key: "id", Value: "1"}}
+	s.a.RemoveApplicationImage(s.ctx)
+
+	assert.Equal(s.T(), 200, s.recorder.Code)
+}
+
 func (s *ApplicationSuite) Test_UploadAppImage_WithSaveError_expectServerError() {
 	s.db.User(5).App(1)
 

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -452,13 +452,17 @@ func (s *ApplicationSuite) Test_RemoveAppImage_noCustomizedImage() {
 func (s *ApplicationSuite) Test_RemoveAppImage_expectSuccess() {
 	s.db.User(5)
 
-	s.db.CreateApplication(&model.Application{UserID: 5, ID: 1, Image: "existing.png"})
-	fakeImage(s.T(), "existing.png")
+	imageFile := "existing.png"
+	s.db.CreateApplication(&model.Application{UserID: 5, ID: 1, Image: imageFile})
+	fakeImage(s.T(), imageFile)
 
 	test.WithUser(s.ctx, 5)
 	s.ctx.Request = httptest.NewRequest("DELETE", "/irrelevant", nil)
 	s.ctx.Params = gin.Params{{Key: "id", Value: "1"}}
 	s.a.RemoveApplicationImage(s.ctx)
+
+	_, err := os.Stat(imageFile)
+	assert.True(s.T(), os.IsNotExist(err))
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
 }

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -365,6 +365,78 @@
             }
           }
         }
+      },
+      "delete": {
+        "security": [
+          {
+            "clientTokenAuthorizationHeader": []
+          },
+          {
+            "clientTokenHeader": []
+          },
+          {
+            "clientTokenQuery": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "application"
+        ],
+        "summary": "Deletes an image of an application.",
+        "operationId": "removeAppImage",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "the application id",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "500": {
+            "description": "Server Error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
       }
     },
     "/application/{id}/message": {

--- a/router/router.go
+++ b/router/router.go
@@ -119,6 +119,8 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 
 			app.POST("/:id/image", applicationHandler.UploadApplicationImage)
 
+			app.DELETE("/:id/image", applicationHandler.RemoveApplicationImage)
+
 			app.PUT("/:id", applicationHandler.UpdateApplication)
 
 			app.DELETE("/:id", applicationHandler.DeleteApplication)


### PR DESCRIPTION
I have a few comments:

1. ~~I don't know if the swagger comments are generated or if I have to manually add them before the function.~~
2. ~~I am also not sure whether an error message makes sense, in case there is no image. IMO it should be a warning or info message, but not sure how to generate such a type.~~
3. I am not a UI person. I have ideas, but how to realize them with HTML/CSS is another story. It would take me a few days to figure these things out. But I suggest that there is an overlay image (an `x`) in the bottom right corner of the icon when hovered over the icon in the frontend. Upon click, the API is called. (The onclick js I can most likely do, but no idea how to do the overlay image.)

Update: ~~I will also write the test cases as soon as the specs are finished for the API call.~~ Tests added.