### PR TITLE
Add application message priority default

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -44,10 +44,10 @@ type ApplicationParams struct {
 	//
 	// example: Backup server for the interwebs
 	Description string `form:"description" query:"description" json:"description"`
-	// The description of the application.
+	// The message priority default for the application.
 	//
-	// example: Backup server for the interwebs
-	PriorityDefault int `form:"priorityDefault" query:"priorityDefault" json:"priorityDefault"`
+	// example: 5
+	DefaultPriority int `form:"defaultPriority" query:"defaultPriority" json:"defaultPriority"`
 }
 
 // CreateApplication creates an application and returns the access token.
@@ -89,7 +89,7 @@ func (a *ApplicationAPI) CreateApplication(ctx *gin.Context) {
 		app := model.Application{
 			Name:            applicationParams.Name,
 			Description:     applicationParams.Description,
-			PriorityDefault: applicationParams.PriorityDefault,
+			DefaultPriority: applicationParams.DefaultPriority,
 			Token:           auth.GenerateNotExistingToken(generateApplicationToken, a.applicationExists),
 			UserID:          auth.GetUserID(ctx),
 			Internal:        false,
@@ -250,7 +250,7 @@ func (a *ApplicationAPI) UpdateApplication(ctx *gin.Context) {
 			if err := ctx.Bind(&applicationParams); err == nil {
 				app.Description = applicationParams.Description
 				app.Name = applicationParams.Name
-				app.PriorityDefault = applicationParams.PriorityDefault
+				app.DefaultPriority = applicationParams.DefaultPriority
 
 				if success := successOrAbort(ctx, 500, a.DB.UpdateApplication(app)); !success {
 					return

--- a/api/application.go
+++ b/api/application.go
@@ -44,7 +44,7 @@ type ApplicationParams struct {
 	//
 	// example: Backup server for the interwebs
 	Description string `form:"description" query:"description" json:"description"`
-	// The message priority default for the application.
+	// The default priority of messages sent by this application. Defaults to 0.
 	//
 	// example: 5
 	DefaultPriority int `form:"defaultPriority" query:"defaultPriority" json:"defaultPriority"`

--- a/api/application.go
+++ b/api/application.go
@@ -44,6 +44,10 @@ type ApplicationParams struct {
 	//
 	// example: Backup server for the interwebs
 	Description string `form:"description" query:"description" json:"description"`
+	// The description of the application.
+	//
+	// example: Backup server for the interwebs
+	PriorityDefault int `form:"priorityDefault" query:"priorityDefault" json:"priorityDefault"`
 }
 
 // CreateApplication creates an application and returns the access token.
@@ -83,11 +87,12 @@ func (a *ApplicationAPI) CreateApplication(ctx *gin.Context) {
 	applicationParams := ApplicationParams{}
 	if err := ctx.Bind(&applicationParams); err == nil {
 		app := model.Application{
-			Name:        applicationParams.Name,
-			Description: applicationParams.Description,
-			Token:       auth.GenerateNotExistingToken(generateApplicationToken, a.applicationExists),
-			UserID:      auth.GetUserID(ctx),
-			Internal:    false,
+			Name:            applicationParams.Name,
+			Description:     applicationParams.Description,
+			PriorityDefault: applicationParams.PriorityDefault,
+			Token:           auth.GenerateNotExistingToken(generateApplicationToken, a.applicationExists),
+			UserID:          auth.GetUserID(ctx),
+			Internal:        false,
 		}
 
 		if success := successOrAbort(ctx, 500, a.DB.CreateApplication(&app)); !success {
@@ -245,6 +250,7 @@ func (a *ApplicationAPI) UpdateApplication(ctx *gin.Context) {
 			if err := ctx.Bind(&applicationParams); err == nil {
 				app.Description = applicationParams.Description
 				app.Name = applicationParams.Name
+				app.PriorityDefault = applicationParams.PriorityDefault
 
 				if success := successOrAbort(ctx, 500, a.DB.UpdateApplication(app)); !success {
 					return

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -92,7 +92,7 @@ func (s *ApplicationSuite) Test_ensureApplicationHasCorrectJsonRepresentation() 
 		Image:       "asd",
 		Internal:    true,
 	}
-	test.JSONEquals(s.T(), actual, `{"id":1,"token":"Aasdasfgeeg","name":"myapp","description":"mydesc", "image": "asd", "internal":true}`)
+	test.JSONEquals(s.T(), actual, `{"id":1,"token":"Aasdasfgeeg","name":"myapp","description":"mydesc", "image": "asd", "internal":true, "priorityDefault":0}`)
 }
 
 func (s *ApplicationSuite) Test_CreateApplication_expectBadRequestOnEmptyName() {

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -92,7 +92,7 @@ func (s *ApplicationSuite) Test_ensureApplicationHasCorrectJsonRepresentation() 
 		Image:       "asd",
 		Internal:    true,
 	}
-	test.JSONEquals(s.T(), actual, `{"id":1,"token":"Aasdasfgeeg","name":"myapp","description":"mydesc", "image": "asd", "internal":true, "priorityDefault":0}`)
+	test.JSONEquals(s.T(), actual, `{"id":1,"token":"Aasdasfgeeg","name":"myapp","description":"mydesc", "image": "asd", "internal":true, "defaultPriority":0}`)
 }
 
 func (s *ApplicationSuite) Test_CreateApplication_expectBadRequestOnEmptyName() {
@@ -519,6 +519,29 @@ func (s *ApplicationSuite) Test_UpdateApplicationName_expectSuccess() {
 		UserID:      5,
 		Name:        "new_name",
 		Description: "",
+	}
+
+	assert.Equal(s.T(), 200, s.recorder.Code)
+	if app, err := s.db.GetApplicationByID(2); assert.NoError(s.T(), err) {
+		assert.Equal(s.T(), expected, app)
+	}
+}
+
+func (s *ApplicationSuite) Test_UpdateApplicationDefaultPriority_expectSuccess() {
+	s.db.User(5).NewAppWithToken(2, "app-2")
+
+	test.WithUser(s.ctx, 5)
+	s.withFormData("name=name&description=&defaultPriority=4")
+	s.ctx.Params = gin.Params{{Key: "id", Value: "2"}}
+	s.a.UpdateApplication(s.ctx)
+
+	expected := &model.Application{
+		ID:              2,
+		Token:           "app-2",
+		UserID:          5,
+		Name:            "name",
+		Description:     "",
+		DefaultPriority: 4,
 	}
 
 	assert.Equal(s.T(), 200, s.recorder.Code)

--- a/api/message.go
+++ b/api/message.go
@@ -371,8 +371,9 @@ func (a *MessageAPI) CreateMessage(ctx *gin.Context) {
 		if strings.TrimSpace(message.Title) == "" {
 			message.Title = application.Name
 		}
-		if message.Priority <= 0 {
-			message.Priority = application.PriorityDefault
+		// if client did not include a priority, then use application default priority
+		if message.Priority == nil {
+			message.Priority = &application.DefaultPriority
 		}
 		message.Date = timeNow()
 		message.ID = 0
@@ -391,9 +392,12 @@ func toInternalMessage(msg *model.MessageExternal) *model.Message {
 		ApplicationID: msg.ApplicationID,
 		Message:       msg.Message,
 		Title:         msg.Title,
-		Priority:      msg.Priority,
 		Date:          msg.Date,
 	}
+	if msg.Priority != nil {
+		res.Priority = *msg.Priority
+	}
+
 	if msg.Extras != nil {
 		res.Extras, _ = json.Marshal(msg.Extras)
 	}
@@ -406,7 +410,7 @@ func toExternalMessage(msg *model.Message) *model.MessageExternal {
 		ApplicationID: msg.ApplicationID,
 		Message:       msg.Message,
 		Title:         msg.Title,
-		Priority:      msg.Priority,
+		Priority:      &msg.Priority,
 		Date:          msg.Date,
 	}
 	if len(msg.Extras) != 0 {

--- a/api/message.go
+++ b/api/message.go
@@ -371,6 +371,9 @@ func (a *MessageAPI) CreateMessage(ctx *gin.Context) {
 		if strings.TrimSpace(message.Title) == "" {
 			message.Title = application.Name
 		}
+		if message.Priority <= 0 {
+			message.Priority = application.PriorityDefault
+		}
 		message.Date = timeNow()
 		message.ID = 0
 		msgInternal := toInternalMessage(&message)

--- a/api/message.go
+++ b/api/message.go
@@ -371,10 +371,11 @@ func (a *MessageAPI) CreateMessage(ctx *gin.Context) {
 		if strings.TrimSpace(message.Title) == "" {
 			message.Title = application.Name
 		}
-		// if client did not include a priority, then use application default priority
+
 		if message.Priority == nil {
 			message.Priority = &application.DefaultPriority
 		}
+
 		message.Date = timeNow()
 		message.ID = 0
 		msgInternal := toInternalMessage(&message)

--- a/api/message_test.go
+++ b/api/message_test.go
@@ -338,6 +338,28 @@ func (s *MessageSuite) Test_CreateMessage_onJson_allParams() {
 	assert.Equal(s.T(), expected, s.notifiedMessage)
 }
 
+func (s *MessageSuite) Test_CreateMessage_WithDefaultPriority() {
+	t, _ := time.Parse("2006/01/02", "2017/01/02")
+
+	timeNow = func() time.Time { return t }
+	defer func() { timeNow = time.Now }()
+
+	auth.RegisterAuthentication(s.ctx, nil, 4, "app-token")
+	s.db.User(4).AppWithTokenAndPriorityDefault(8, "app-token", 5)
+	s.ctx.Request = httptest.NewRequest("POST", "/message", strings.NewReader(`{"title": "mytitle", "message": "mymessage"}`))
+	s.ctx.Request.Header.Set("Content-Type", "application/json")
+
+	s.a.CreateMessage(s.ctx)
+
+	msgs, err := s.db.GetMessagesByApplication(8)
+	assert.NoError(s.T(), err)
+	expected := &model.MessageExternal{ID: 1, ApplicationID: 8, Title: "mytitle", Message: "mymessage", Priority: 5, Date: t}
+	assert.Len(s.T(), msgs, 1)
+	assert.Equal(s.T(), expected, toExternalMessage(msgs[0]))
+	assert.Equal(s.T(), 200, s.recorder.Code)
+	assert.Equal(s.T(), expected, s.notifiedMessage)
+}
+
 func (s *MessageSuite) Test_CreateMessage_WithTitle() {
 	t, _ := time.Parse("2006/01/02", "2017/01/02")
 	timeNow = func() time.Time { return t }

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -2063,6 +2063,13 @@
         "image"
       ],
       "properties": {
+        "defaultPriority": {
+          "description": "The priority default of a message for an application. If the sender does not provide a priority, then\nthe message priority will be set to this value. Defaults to 0.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "DefaultPriority",
+          "example": 4
+        },
         "description": {
           "description": "The description of the application.",
           "type": "string",
@@ -2115,6 +2122,13 @@
         "name"
       ],
       "properties": {
+        "defaultPriority": {
+          "description": "The message priority default for the application.",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "DefaultPriority",
+          "example": 5
+        },
         "description": {
           "description": "The description of the application.",
           "type": "string",

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -2340,7 +2340,7 @@
           "example": "**Backup** was successfully finished."
         },
         "priority": {
-          "description": "The priority of the message.",
+          "description": "The priority of the message. If unset, then the default priority of the\napplication will be used.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "Priority",

--- a/docs/spec.json
+++ b/docs/spec.json
@@ -2064,7 +2064,7 @@
       ],
       "properties": {
         "defaultPriority": {
-          "description": "The priority default of a message for an application. If the sender does not provide a priority, then\nthe message priority will be set to this value. Defaults to 0.",
+          "description": "The default priority of messages sent by this application. Defaults to 0.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "DefaultPriority",
@@ -2123,7 +2123,7 @@
       ],
       "properties": {
         "defaultPriority": {
-          "description": "The message priority default for the application.",
+          "description": "The default priority of messages sent by this application. Defaults to 0.",
           "type": "integer",
           "format": "int64",
           "x-go-name": "DefaultPriority",

--- a/model/application.go
+++ b/model/application.go
@@ -42,8 +42,7 @@ type Application struct {
 	// example: image/image.jpeg
 	Image    string            `gorm:"type:text" json:"image"`
 	Messages []MessageExternal `json:"-"`
-	// The priority default of a message for an application. If the sender does not provide a priority, then
-	// the message priority will be set to this value. Defaults to 0.
+	// The default priority of messages sent by this application. Defaults to 0.
 	//
 	// required: false
 	// example: 4

--- a/model/application.go
+++ b/model/application.go
@@ -47,5 +47,5 @@ type Application struct {
 	//
 	// required: false
 	// example: 4
-	PriorityDefault int `gorm:"default:0" form:"priorityDefault" query:"priorityDefault" json:"priorityDefault"`
+	DefaultPriority int `form:"defaultPriority" query:"defaultPriority" json:"defaultPriority"`
 }

--- a/model/application.go
+++ b/model/application.go
@@ -42,4 +42,10 @@ type Application struct {
 	// example: image/image.jpeg
 	Image    string            `gorm:"type:text" json:"image"`
 	Messages []MessageExternal `json:"-"`
+	// The priority default of a message for an application. If the sender does not provide a priority, then
+	// the message priority will be set to this value. Defaults to 0.
+	//
+	// required: false
+	// example: 4
+	PriorityDefault int `gorm:"default:0" form:"priorityDefault" query:"priorityDefault" json:"priorityDefault"`
 }

--- a/model/message.go
+++ b/model/message.go
@@ -45,7 +45,7 @@ type MessageExternal struct {
 	// The priority of the message.
 	//
 	// example: 2
-	Priority int `form:"priority" query:"priority" json:"priority"`
+	Priority *int `form:"priority" query:"priority" json:"priority"`
 	// The extra data sent along the message.
 	//
 	// The extra fields are stored in a key-value scheme. Only accepted in CreateMessage requests with application/json content-type.

--- a/model/message.go
+++ b/model/message.go
@@ -42,7 +42,8 @@ type MessageExternal struct {
 	//
 	// example: Backup
 	Title string `form:"title" query:"title" json:"title"`
-	// The priority of the message.
+	// The priority of the message. If unset, then the default priority of the
+	// application will be used.
 	//
 	// example: 2
 	Priority *int `form:"priority" query:"priority" json:"priority"`

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -70,7 +70,7 @@ func NewManager(db Database, directory string, mux *gin.RouterGroup, notifier No
 			internalMsg := &model.Message{
 				ApplicationID: message.Message.ApplicationID,
 				Title:         message.Message.Title,
-				Priority:      message.Message.Priority,
+				Priority:      *message.Message.Priority,
 				Date:          message.Message.Date,
 				Message:       message.Message.Message,
 			}

--- a/plugin/messagehandler.go
+++ b/plugin/messagehandler.go
@@ -26,7 +26,7 @@ func (c redirectToChannel) SendMessage(msg compat.Message) error {
 			ApplicationID: c.ApplicationID,
 			Message:       msg.Message,
 			Title:         msg.Title,
-			Priority:      msg.Priority,
+			Priority:      &msg.Priority,
 			Date:          time.Now(),
 			Extras:        msg.Extras,
 		},

--- a/test/testdb/database.go
+++ b/test/testdb/database.go
@@ -138,6 +138,22 @@ func (ab *AppClientBuilder) newAppWithTokenAndName(id uint, token, name string, 
 	return application
 }
 
+// AppWithTokenAndPriorityDefault creates an application with a token and priorityDefault and returns a message builder.
+func (ab *AppClientBuilder) AppWithTokenAndPriorityDefault(id uint, token string, priorityDefault int) *MessageBuilder {
+	return ab.appWithTokenAndPriorityDefault(id, token, priorityDefault, false)
+}
+
+func (ab *AppClientBuilder) appWithTokenAndPriorityDefault(id uint, token string, priorityDefault int, internal bool) *MessageBuilder {
+	ab.newAppWithTokenAndPriorityDefault(id, token, priorityDefault, internal)
+	return &MessageBuilder{db: ab.db, appID: id}
+}
+
+func (ab *AppClientBuilder) newAppWithTokenAndPriorityDefault(id uint, token string, priorityDefault int, internal bool) *model.Application {
+	application := &model.Application{ID: id, UserID: ab.userID, Token: token, PriorityDefault: priorityDefault, Internal: internal}
+	ab.db.CreateApplication(application)
+	return application
+}
+
 // Client creates a client and returns itself.
 func (ab *AppClientBuilder) Client(id uint) *AppClientBuilder {
 	return ab.ClientWithToken(id, "client"+fmt.Sprint(id))

--- a/test/testdb/database.go
+++ b/test/testdb/database.go
@@ -138,20 +138,11 @@ func (ab *AppClientBuilder) newAppWithTokenAndName(id uint, token, name string, 
 	return application
 }
 
-// AppWithTokenAndPriorityDefault creates an application with a token and priorityDefault and returns a message builder.
-func (ab *AppClientBuilder) AppWithTokenAndPriorityDefault(id uint, token string, priorityDefault int) *MessageBuilder {
-	return ab.appWithTokenAndPriorityDefault(id, token, priorityDefault, false)
-}
-
-func (ab *AppClientBuilder) appWithTokenAndPriorityDefault(id uint, token string, priorityDefault int, internal bool) *MessageBuilder {
-	ab.newAppWithTokenAndPriorityDefault(id, token, priorityDefault, internal)
-	return &MessageBuilder{db: ab.db, appID: id}
-}
-
-func (ab *AppClientBuilder) newAppWithTokenAndPriorityDefault(id uint, token string, priorityDefault int, internal bool) *model.Application {
-	application := &model.Application{ID: id, UserID: ab.userID, Token: token, PriorityDefault: priorityDefault, Internal: internal}
+// AppWithTokenAndDefaultPriority creates an application with a token and defaultPriority and returns a message builder.
+func (ab *AppClientBuilder) AppWithTokenAndDefaultPriority(id uint, token string, defaultPriority int) *MessageBuilder {
+	application := &model.Application{ID: id, UserID: ab.userID, Token: token, DefaultPriority: defaultPriority}
 	ab.db.CreateApplication(application)
-	return application
+	return &MessageBuilder{db: ab.db, appID: id}
 }
 
 // Client creates a client and returns itself.

--- a/test/testdb/database_test.go
+++ b/test/testdb/database_test.go
@@ -127,6 +127,7 @@ func (s *DatabaseSuite) Test_Apps() {
 	userBuilder.InternalAppWithTokenAndName(10, "test-tokeni-2", "app name")
 	userBuilder.AppWithToken(11, "test-token-3")
 	userBuilder.InternalAppWithToken(12, "test-tokeni-3")
+	userBuilder.AppWithTokenAndDefaultPriority(13, "test-tokeni-4", 4)
 
 	s.db.AssertAppExist(1)
 	s.db.AssertAppExist(2)
@@ -140,6 +141,7 @@ func (s *DatabaseSuite) Test_Apps() {
 	s.db.AssertAppExist(10)
 	s.db.AssertAppExist(11)
 	s.db.AssertAppExist(12)
+	s.db.AssertAppExist(13)
 
 	s.db.DeleteApplicationByID(2)
 

--- a/ui/src/application/AddApplicationDialog.tsx
+++ b/ui/src/application/AddApplicationDialog.tsx
@@ -6,6 +6,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 import Tooltip from '@material-ui/core/Tooltip';
+import {NumberField} from '../common/NumberField';
 import React, {Component} from 'react';
 
 interface IProps {
@@ -60,13 +61,12 @@ export default class AddDialog extends Component<IProps, IState> {
                         fullWidth
                         multiline
                     />
-                    <TextField
+                    <NumberField
                         margin="dense"
-                        className="DefaultPriority"
+                        className="priority"
                         label="Default Priority"
-                        type="number"
                         value={defaultPriority}
-                        onChange={this.handleChangeNumeric.bind(this, 'defaultPriority')}
+                        onChange={(value) => this.setState({defaultPriority: value})}
                         fullWidth
                     />
                 </DialogContent>
@@ -93,15 +93,5 @@ export default class AddDialog extends Component<IProps, IState> {
         const state = this.state;
         state[propertyName] = event.target.value;
         this.setState(state);
-    }
-
-    private handleChangeNumeric(propertyName: string, event: React.ChangeEvent<HTMLInputElement>) {
-        const state = this.state;
-
-        const regex = /^[0-9\b]+$/;
-        if (event.target.value === '' || regex.test(event.target.value)) {
-            state[propertyName] = event.target.value;
-            this.setState(state);
-        }
     }
 }

--- a/ui/src/application/AddApplicationDialog.tsx
+++ b/ui/src/application/AddApplicationDialog.tsx
@@ -10,23 +10,24 @@ import React, {Component} from 'react';
 
 interface IProps {
     fClose: VoidFunction;
-    fOnSubmit: (name: string, description: string) => void;
+    fOnSubmit: (name: string, description: string, priorityDefault: number) => void;
 }
 
 interface IState {
     name: string;
     description: string;
+    priorityDefault: number;
 }
 
 export default class AddDialog extends Component<IProps, IState> {
-    public state = {name: '', description: ''};
+    public state = {name: '', description: '', priorityDefault: 0};
 
     public render() {
         const {fClose, fOnSubmit} = this.props;
-        const {name, description} = this.state;
+        const {name, description, priorityDefault} = this.state;
         const submitEnabled = this.state.name.length !== 0;
         const submitAndClose = () => {
-            fOnSubmit(name, description);
+            fOnSubmit(name, description, priorityDefault);
             fClose();
         };
         return (
@@ -59,6 +60,15 @@ export default class AddDialog extends Component<IProps, IState> {
                         fullWidth
                         multiline
                     />
+                    <TextField
+                        margin="dense"
+                        className="PriorityDefault"
+                        label="Priority Default"
+                        value={priorityDefault}
+                        onChange={this.handleChangeNumeric.bind(this, 'priorityDefault')}
+                        fullWidth
+                        multiline
+                    />
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={fClose}>Cancel</Button>
@@ -83,5 +93,15 @@ export default class AddDialog extends Component<IProps, IState> {
         const state = this.state;
         state[propertyName] = event.target.value;
         this.setState(state);
+    }
+
+    private handleChangeNumeric(propertyName: string, event: React.ChangeEvent<HTMLInputElement>) {
+        const state = this.state;
+
+        const regex = /^[0-9\b]+$/;
+        if (event.target.value === "" || regex.test(event.target.value)) {
+            state[propertyName] = event.target.value;
+            this.setState(state);
+        }
     }
 }

--- a/ui/src/application/AddApplicationDialog.tsx
+++ b/ui/src/application/AddApplicationDialog.tsx
@@ -10,24 +10,24 @@ import React, {Component} from 'react';
 
 interface IProps {
     fClose: VoidFunction;
-    fOnSubmit: (name: string, description: string, priorityDefault: number) => void;
+    fOnSubmit: (name: string, description: string, defaultPriority: number) => void;
 }
 
 interface IState {
     name: string;
     description: string;
-    priorityDefault: number;
+    defaultPriority: number;
 }
 
 export default class AddDialog extends Component<IProps, IState> {
-    public state = {name: '', description: '', priorityDefault: 0};
+    public state = {name: '', description: '', defaultPriority: 0};
 
     public render() {
         const {fClose, fOnSubmit} = this.props;
-        const {name, description, priorityDefault} = this.state;
+        const {name, description, defaultPriority} = this.state;
         const submitEnabled = this.state.name.length !== 0;
         const submitAndClose = () => {
-            fOnSubmit(name, description, priorityDefault);
+            fOnSubmit(name, description, defaultPriority);
             fClose();
         };
         return (
@@ -62,12 +62,12 @@ export default class AddDialog extends Component<IProps, IState> {
                     />
                     <TextField
                         margin="dense"
-                        className="PriorityDefault"
-                        label="Priority Default"
-                        value={priorityDefault}
-                        onChange={this.handleChangeNumeric.bind(this, 'priorityDefault')}
+                        className="DefaultPriority"
+                        label="Default Priority"
+                        type="number"
+                        value={defaultPriority}
+                        onChange={this.handleChangeNumeric.bind(this, 'defaultPriority')}
                         fullWidth
-                        multiline
                     />
                 </DialogContent>
                 <DialogActions>

--- a/ui/src/application/AddApplicationDialog.tsx
+++ b/ui/src/application/AddApplicationDialog.tsx
@@ -99,7 +99,7 @@ export default class AddDialog extends Component<IProps, IState> {
         const state = this.state;
 
         const regex = /^[0-9\b]+$/;
-        if (event.target.value === "" || regex.test(event.target.value)) {
+        if (event.target.value === '' || regex.test(event.target.value)) {
             state[propertyName] = event.target.value;
             this.setState(state);
         }

--- a/ui/src/application/AppStore.ts
+++ b/ui/src/application/AppStore.ts
@@ -35,15 +35,32 @@ export class AppStore extends BaseStore<IApplication> {
     };
 
     @action
-    public update = async (id: number, name: string, description: string, defaultPriority: number): Promise<void> => {
-        await axios.put(`${config.get('url')}application/${id}`, {name, description, defaultPriority: Number(defaultPriority)});
+    public update = async (
+        id: number,
+        name: string,
+        description: string,
+        defaultPriority: number
+    ): Promise<void> => {
+        await axios.put(`${config.get('url')}application/${id}`, {
+            name,
+            description,
+            defaultPriority: Number(defaultPriority),
+        });
         await this.refresh();
         this.snack('Application updated');
     };
 
     @action
-    public create = async (name: string, description: string, defaultPriority: number): Promise<void> => {
-        await axios.post(`${config.get('url')}application`, {name, description, defaultPriority: Number(defaultPriority)});
+    public create = async (
+        name: string,
+        description: string,
+        defaultPriority: number
+    ): Promise<void> => {
+        await axios.post(`${config.get('url')}application`, {
+            name,
+            description,
+            defaultPriority: Number(defaultPriority),
+        });
         await this.refresh();
         this.snack('Application created');
     };

--- a/ui/src/application/AppStore.ts
+++ b/ui/src/application/AppStore.ts
@@ -44,7 +44,7 @@ export class AppStore extends BaseStore<IApplication> {
         await axios.put(`${config.get('url')}application/${id}`, {
             name,
             description,
-            defaultPriority: Number(defaultPriority),
+            defaultPriority,
         });
         await this.refresh();
         this.snack('Application updated');
@@ -59,7 +59,7 @@ export class AppStore extends BaseStore<IApplication> {
         await axios.post(`${config.get('url')}application`, {
             name,
             description,
-            defaultPriority: Number(defaultPriority),
+            defaultPriority,
         });
         await this.refresh();
         this.snack('Application created');

--- a/ui/src/application/AppStore.ts
+++ b/ui/src/application/AppStore.ts
@@ -35,15 +35,15 @@ export class AppStore extends BaseStore<IApplication> {
     };
 
     @action
-    public update = async (id: number, name: string, description: string): Promise<void> => {
-        await axios.put(`${config.get('url')}application/${id}`, {name, description});
+    public update = async (id: number, name: string, description: string, priorityDefault: number): Promise<void> => {
+        await axios.put(`${config.get('url')}application/${id}`, {name, description, priorityDefault: Number(priorityDefault)});
         await this.refresh();
         this.snack('Application updated');
     };
 
     @action
-    public create = async (name: string, description: string): Promise<void> => {
-        await axios.post(`${config.get('url')}application`, {name, description});
+    public create = async (name: string, description: string, priorityDefault: number): Promise<void> => {
+        await axios.post(`${config.get('url')}application`, {name, description, priorityDefault: Number(priorityDefault)});
         await this.refresh();
         this.snack('Application created');
     };

--- a/ui/src/application/AppStore.ts
+++ b/ui/src/application/AppStore.ts
@@ -35,15 +35,15 @@ export class AppStore extends BaseStore<IApplication> {
     };
 
     @action
-    public update = async (id: number, name: string, description: string, priorityDefault: number): Promise<void> => {
-        await axios.put(`${config.get('url')}application/${id}`, {name, description, priorityDefault: Number(priorityDefault)});
+    public update = async (id: number, name: string, description: string, defaultPriority: number): Promise<void> => {
+        await axios.put(`${config.get('url')}application/${id}`, {name, description, defaultPriority: Number(defaultPriority)});
         await this.refresh();
         this.snack('Application updated');
     };
 
     @action
-    public create = async (name: string, description: string, priorityDefault: number): Promise<void> => {
-        await axios.post(`${config.get('url')}application`, {name, description, priorityDefault: Number(priorityDefault)});
+    public create = async (name: string, description: string, defaultPriority: number): Promise<void> => {
+        await axios.post(`${config.get('url')}application`, {name, description, defaultPriority: Number(defaultPriority)});
         await this.refresh();
         this.snack('Application created');
     };

--- a/ui/src/application/Applications.tsx
+++ b/ui/src/application/Applications.tsx
@@ -66,6 +66,7 @@ class Applications extends Component<Stores<'appStore'>> {
                                     <TableCell>Name</TableCell>
                                     <TableCell>Token</TableCell>
                                     <TableCell>Description</TableCell>
+                                    <TableCell>Priority</TableCell>
                                     <TableCell />
                                     <TableCell />
                                 </TableRow>
@@ -75,6 +76,7 @@ class Applications extends Component<Stores<'appStore'>> {
                                     <Row
                                         key={app.id}
                                         description={app.description}
+                                        priorityDefault={app.priorityDefault}
                                         image={app.image}
                                         name={app.name}
                                         value={app.token}
@@ -103,11 +105,12 @@ class Applications extends Component<Stores<'appStore'>> {
                 {updateId !== false && (
                     <UpdateDialog
                         fClose={() => (this.updateId = false)}
-                        fOnSubmit={(name, description) =>
-                            appStore.update(updateId, name, description)
+                        fOnSubmit={(name, description, priorityDefault) =>
+                            appStore.update(updateId, name, description, priorityDefault)
                         }
                         initialDescription={appStore.getByID(updateId).description}
                         initialName={appStore.getByID(updateId).name}
+                        initialPriorityDefault={appStore.getByID(updateId).priorityDefault}
                     />
                 )}
                 {deleteId !== false && (
@@ -147,6 +150,7 @@ interface IRowProps {
     value: string;
     noDelete: boolean;
     description: string;
+    priorityDefault: number;
     fUpload: VoidFunction;
     image: string;
     fDelete: VoidFunction;
@@ -154,7 +158,7 @@ interface IRowProps {
 }
 
 const Row: SFC<IRowProps> = observer(
-    ({name, value, noDelete, description, fDelete, fUpload, image, fEdit}) => (
+    ({ name, value, noDelete, description, priorityDefault, fDelete, fUpload, image, fEdit }) => (
         <TableRow>
             <TableCell padding="default">
                 <div style={{display: 'flex'}}>
@@ -169,6 +173,7 @@ const Row: SFC<IRowProps> = observer(
                 <CopyableSecret value={value} style={{display: 'flex', alignItems: 'center'}} />
             </TableCell>
             <TableCell>{description}</TableCell>
+            <TableCell>{priorityDefault}</TableCell>
             <TableCell align="right" padding="none">
                 <IconButton onClick={fEdit} className="edit">
                     <Edit />

--- a/ui/src/application/Applications.tsx
+++ b/ui/src/application/Applications.tsx
@@ -158,7 +158,7 @@ interface IRowProps {
 }
 
 const Row: SFC<IRowProps> = observer(
-    ({ name, value, noDelete, description, defaultPriority, fDelete, fUpload, image, fEdit }) => (
+    ({name, value, noDelete, description, defaultPriority, fDelete, fUpload, image, fEdit}) => (
         <TableRow>
             <TableCell padding="default">
                 <div style={{display: 'flex'}}>

--- a/ui/src/application/Applications.tsx
+++ b/ui/src/application/Applications.tsx
@@ -76,7 +76,7 @@ class Applications extends Component<Stores<'appStore'>> {
                                     <Row
                                         key={app.id}
                                         description={app.description}
-                                        priorityDefault={app.priorityDefault}
+                                        defaultPriority={app.defaultPriority}
                                         image={app.image}
                                         name={app.name}
                                         value={app.token}
@@ -105,12 +105,12 @@ class Applications extends Component<Stores<'appStore'>> {
                 {updateId !== false && (
                     <UpdateDialog
                         fClose={() => (this.updateId = false)}
-                        fOnSubmit={(name, description, priorityDefault) =>
-                            appStore.update(updateId, name, description, priorityDefault)
+                        fOnSubmit={(name, description, defaultPriority) =>
+                            appStore.update(updateId, name, description, defaultPriority)
                         }
                         initialDescription={appStore.getByID(updateId).description}
                         initialName={appStore.getByID(updateId).name}
-                        initialPriorityDefault={appStore.getByID(updateId).priorityDefault}
+                        initialDefaultPriority={appStore.getByID(updateId).defaultPriority}
                     />
                 )}
                 {deleteId !== false && (
@@ -150,7 +150,7 @@ interface IRowProps {
     value: string;
     noDelete: boolean;
     description: string;
-    priorityDefault: number;
+    defaultPriority: number;
     fUpload: VoidFunction;
     image: string;
     fDelete: VoidFunction;
@@ -158,7 +158,7 @@ interface IRowProps {
 }
 
 const Row: SFC<IRowProps> = observer(
-    ({ name, value, noDelete, description, priorityDefault, fDelete, fUpload, image, fEdit }) => (
+    ({ name, value, noDelete, description, defaultPriority, fDelete, fUpload, image, fEdit }) => (
         <TableRow>
             <TableCell padding="default">
                 <div style={{display: 'flex'}}>
@@ -173,7 +173,7 @@ const Row: SFC<IRowProps> = observer(
                 <CopyableSecret value={value} style={{display: 'flex', alignItems: 'center'}} />
             </TableCell>
             <TableCell>{description}</TableCell>
-            <TableCell>{priorityDefault}</TableCell>
+            <TableCell>{defaultPriority}</TableCell>
             <TableCell align="right" padding="none">
                 <IconButton onClick={fEdit} className="edit">
                     <Edit />

--- a/ui/src/application/UpdateApplicationDialog.tsx
+++ b/ui/src/application/UpdateApplicationDialog.tsx
@@ -10,33 +10,36 @@ import React, {Component} from 'react';
 
 interface IProps {
     fClose: VoidFunction;
-    fOnSubmit: (name: string, description: string) => void;
+    fOnSubmit: (name: string, description: string, priorityDefault: number) => void;
     initialName: string;
     initialDescription: string;
+    initialPriorityDefault: number;
 }
 
 interface IState {
     name: string;
     description: string;
+    priorityDefault: number;
 }
 
 export default class UpdateDialog extends Component<IProps, IState> {
-    public state = {name: '', description: ''};
+    public state = {name: '', description: 'some', priorityDefault: 0};
 
     constructor(props: IProps) {
         super(props);
         this.state = {
             name: props.initialName,
             description: props.initialDescription,
+            priorityDefault: props.initialPriorityDefault,
         };
     }
 
     public render() {
         const {fClose, fOnSubmit} = this.props;
-        const {name, description} = this.state;
+        const {name, description, priorityDefault} = this.state;
         const submitEnabled = this.state.name.length !== 0;
         const submitAndClose = () => {
-            fOnSubmit(name, description);
+            fOnSubmit(name, description, priorityDefault);
             fClose();
         };
         return (
@@ -69,6 +72,16 @@ export default class UpdateDialog extends Component<IProps, IState> {
                         fullWidth
                         multiline
                     />
+                    <TextField
+                        margin="dense"
+                        className="PriorityDefault"
+                        label="Priority Default"
+                        type="text"
+                        value={priorityDefault}
+                        onChange={this.handleChangeNumeric.bind(this, 'priorityDefault')}
+                        fullWidth
+                        multiline
+                    />
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={fClose}>Cancel</Button>
@@ -93,5 +106,15 @@ export default class UpdateDialog extends Component<IProps, IState> {
         const state = this.state;
         state[propertyName] = event.target.value;
         this.setState(state);
+    }
+
+    private handleChangeNumeric(propertyName: string, event: React.ChangeEvent<HTMLInputElement>) {
+        const state = this.state;
+
+        const regex = /^[0-9\b]+$/;
+        if (event.target.value === "" || regex.test(event.target.value)) {
+            state[propertyName] = event.target.value;
+            this.setState(state);
+        }
     }
 }

--- a/ui/src/application/UpdateApplicationDialog.tsx
+++ b/ui/src/application/UpdateApplicationDialog.tsx
@@ -10,36 +10,36 @@ import React, {Component} from 'react';
 
 interface IProps {
     fClose: VoidFunction;
-    fOnSubmit: (name: string, description: string, priorityDefault: number) => void;
+    fOnSubmit: (name: string, description: string, defaultPriority: number) => void;
     initialName: string;
     initialDescription: string;
-    initialPriorityDefault: number;
+    initialDefaultPriority: number;
 }
 
 interface IState {
     name: string;
     description: string;
-    priorityDefault: number;
+    defaultPriority: number;
 }
 
 export default class UpdateDialog extends Component<IProps, IState> {
-    public state = {name: '', description: 'some', priorityDefault: 0};
+    public state = {name: '', description: 'some', defaultPriority: 0};
 
     constructor(props: IProps) {
         super(props);
         this.state = {
             name: props.initialName,
             description: props.initialDescription,
-            priorityDefault: props.initialPriorityDefault,
+            defaultPriority: props.initialDefaultPriority,
         };
     }
 
     public render() {
         const {fClose, fOnSubmit} = this.props;
-        const {name, description, priorityDefault} = this.state;
+        const {name, description, defaultPriority} = this.state;
         const submitEnabled = this.state.name.length !== 0;
         const submitAndClose = () => {
-            fOnSubmit(name, description, priorityDefault);
+            fOnSubmit(name, description, defaultPriority);
             fClose();
         };
         return (
@@ -74,13 +74,12 @@ export default class UpdateDialog extends Component<IProps, IState> {
                     />
                     <TextField
                         margin="dense"
-                        className="PriorityDefault"
-                        label="Priority Default"
-                        type="text"
-                        value={priorityDefault}
-                        onChange={this.handleChangeNumeric.bind(this, 'priorityDefault')}
+                        className="DefaultPriority"
+                        label="Default Priority"
+                        type="number"
+                        value={defaultPriority}
+                        onChange={this.handleChangeNumeric.bind(this, 'defaultPriority')}
                         fullWidth
-                        multiline
                     />
                 </DialogContent>
                 <DialogActions>

--- a/ui/src/application/UpdateApplicationDialog.tsx
+++ b/ui/src/application/UpdateApplicationDialog.tsx
@@ -111,7 +111,7 @@ export default class UpdateDialog extends Component<IProps, IState> {
         const state = this.state;
 
         const regex = /^[0-9\b]+$/;
-        if (event.target.value === "" || regex.test(event.target.value)) {
+        if (event.target.value === '' || regex.test(event.target.value)) {
             state[propertyName] = event.target.value;
             this.setState(state);
         }

--- a/ui/src/application/UpdateApplicationDialog.tsx
+++ b/ui/src/application/UpdateApplicationDialog.tsx
@@ -6,6 +6,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import TextField from '@material-ui/core/TextField';
 import Tooltip from '@material-ui/core/Tooltip';
+import {NumberField} from '../common/NumberField';
 import React, {Component} from 'react';
 
 interface IProps {
@@ -72,13 +73,12 @@ export default class UpdateDialog extends Component<IProps, IState> {
                         fullWidth
                         multiline
                     />
-                    <TextField
+                    <NumberField
                         margin="dense"
-                        className="DefaultPriority"
+                        className="priority"
                         label="Default Priority"
-                        type="number"
                         value={defaultPriority}
-                        onChange={this.handleChangeNumeric.bind(this, 'defaultPriority')}
+                        onChange={(value) => this.setState({defaultPriority: value})}
                         fullWidth
                     />
                 </DialogContent>
@@ -105,15 +105,5 @@ export default class UpdateDialog extends Component<IProps, IState> {
         const state = this.state;
         state[propertyName] = event.target.value;
         this.setState(state);
-    }
-
-    private handleChangeNumeric(propertyName: string, event: React.ChangeEvent<HTMLInputElement>) {
-        const state = this.state;
-
-        const regex = /^[0-9\b]+$/;
-        if (event.target.value === '' || regex.test(event.target.value)) {
-            state[propertyName] = event.target.value;
-            this.setState(state);
-        }
     }
 }

--- a/ui/src/application/UpdateApplicationDialog.tsx
+++ b/ui/src/application/UpdateApplicationDialog.tsx
@@ -24,7 +24,7 @@ interface IState {
 }
 
 export default class UpdateDialog extends Component<IProps, IState> {
-    public state = {name: '', description: 'some', defaultPriority: 0};
+    public state = {name: '', description: '', defaultPriority: 0};
 
     constructor(props: IProps) {
         super(props);

--- a/ui/src/common/NumberField.tsx
+++ b/ui/src/common/NumberField.tsx
@@ -1,0 +1,36 @@
+import {TextField, TextFieldProps} from '@material-ui/core';
+import React from 'react';
+
+export interface NumberFieldProps {
+    value: number;
+    onChange: (value: number) => void;
+}
+
+export const NumberField = ({
+    value,
+    onChange,
+    ...props
+}: NumberFieldProps & Omit<TextFieldProps, 'value' | 'onChange'>) => {
+    const [stringValue, setStringValue] = React.useState<string>(value.toString());
+    const [error, setError] = React.useState('');
+
+    return (
+        <TextField
+            value={stringValue}
+            type="number"
+            helperText={error}
+            error={error !== ''}
+            onChange={(event) => {
+                setStringValue(event.target.value);
+                const i = parseInt(event.target.value, 10);
+                if (!Number.isNaN(i)) {
+                    onChange(i);
+                    setError('');
+                } else {
+                    setError('Invalid number');
+                }
+            }}
+            {...props}
+        />
+    );
+};

--- a/ui/src/tests/application.test.ts
+++ b/ui/src/tests/application.test.ts
@@ -17,7 +17,7 @@ enum Col {
     Name = 2,
     Token = 3,
     Description = 4,
-    PriorityDefault = 5,
+    DefaultPriority = 5,
     EditUpdate = 6,
     EditDelete = 7,
 }

--- a/ui/src/tests/application.test.ts
+++ b/ui/src/tests/application.test.ts
@@ -17,8 +17,9 @@ enum Col {
     Name = 2,
     Token = 3,
     Description = 4,
-    EditUpdate = 5,
-    EditDelete = 6,
+    PriorityDefault = 5,
+    EditUpdate = 6,
+    EditDelete = 7,
 }
 
 const hiddenToken = '•••••••••••••••';

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -5,6 +5,7 @@ export interface IApplication {
     description: string;
     image: string;
     internal: boolean;
+    priorityDefault: number;
 }
 
 export interface IClient {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -5,7 +5,7 @@ export interface IApplication {
     description: string;
     image: string;
     internal: boolean;
-    priorityDefault: number;
+    defaultPriority: number;
 }
 
 export interface IClient {


### PR DESCRIPTION
This PR adds the feature discussed in #312.

It allows a user to set a message priority default at the application level. If a sender includes a priority in the request payload to create a message, then the default will be ignored. If the sender omits the priority, then the default priority is applied to the message.

Any feedback is appreciated!