### PR TITLE
feat: Trusted Proxies

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -23,6 +23,10 @@ server:
 
   responseheaders: # response headers are added to every response (default: none)
 #    X-Custom-Header: "custom value"
+#
+  trustedproxies: # IPs or IP ranges of trusted proxies. Used to obtain the remote ip via the X-Forwarded-For header. (configure 127.0.0.1 to trust sockets)
+#   - 127.0.0.1/32
+#   - ::1
 
   cors: # Sets cors headers only when needed and provides support for multiple allowed origins. Overrides Access-Control-* Headers in response headers.
     alloworigins:

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ type Configuration struct {
 			AllowMethods []string
 			AllowHeaders []string
 		}
+
+		TrustedProxies []string
 	}
 	Database struct {
 		Dialect    string `default:"sqlite3"`

--- a/router/router.go
+++ b/router/router.go
@@ -27,6 +27,7 @@ import (
 func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Configuration) (*gin.Engine, func()) {
 	g := gin.New()
 
+	g.RemoteIPHeaders = []string{"X-Forwarded-For"}
 	g.SetTrustedProxies(conf.Server.TrustedProxies)
 	g.ForwardedByClientIP = true
 

--- a/router/router.go
+++ b/router/router.go
@@ -27,10 +27,8 @@ import (
 func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Configuration) (*gin.Engine, func()) {
 	g := gin.New()
 
-	if conf.Server.TrustedProxies != nil {
-		g.SetTrustedProxies(conf.Server.TrustedProxies)
-		g.ForwardedByClientIP = true
-	}
+	g.SetTrustedProxies(conf.Server.TrustedProxies)
+	g.ForwardedByClientIP = true
 
 	g.Use(func(ctx *gin.Context) {
 		// Map sockets "@" to 127.0.0.1, because gin-gonic can only trust IPs.

--- a/router/router.go
+++ b/router/router.go
@@ -27,6 +27,18 @@ import (
 func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Configuration) (*gin.Engine, func()) {
 	g := gin.New()
 
+	if conf.Server.TrustedProxies != nil {
+		g.SetTrustedProxies(conf.Server.TrustedProxies)
+		g.ForwardedByClientIP = true
+	}
+
+	g.Use(func(ctx *gin.Context) {
+		// Map sockets "@" to 127.0.0.1, because gin-gonic can only trust IPs.
+		if ctx.Request.RemoteAddr == "@" {
+			ctx.Request.RemoteAddr = "127.0.0.1:65535"
+		}
+	})
+
 	g.Use(gin.LoggerWithFormatter(logFormatter), gin.Recovery(), gerror.Handler(), location.Default())
 	g.NoRoute(gerror.NotFound())
 


### PR DESCRIPTION
Fix #554

Added the option to configuration to allow trusted proxies, is handled the same way as every other `[]string`

However, I had to find a workaround for unix sockets since there was no "official" way for Gin to handle these.

So in short if the request comes from unix socket then the `RemoteAddr` is set to `127.0.0.1` so if the user would like to trust a webserver that communicates on the socket then they would need to trust `127.0.0.1` via the new option.

By default the RemoteAddr is set to `@` on unix socket requests , however, gin only allows IP's within the trusted proxies