### PR TITLE
Loading animations instead of "no messages

### DIFF
--- a/ui/src/common/LoadingSpinner.tsx
+++ b/ui/src/common/LoadingSpinner.tsx
@@ -7,7 +7,7 @@ export default function LoadingSpinner() {
     return (
         <DefaultPage title="" maxWidth={250}>
             <Grid item xs={12} style={{textAlign: 'center'}}>
-                <CircularProgress size={150} />
+                <CircularProgress size={40} />
             </Grid>
         </DefaultPage>
     );

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -1,4 +1,3 @@
-import CircularProgress from '@material-ui/core/CircularProgress';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import React, {Component} from 'react';
@@ -12,6 +11,7 @@ import {observable} from 'mobx';
 import ReactInfinite from 'react-infinite';
 import {IMessage} from '../types';
 import ConfirmDialog from '../common/ConfirmDialog';
+import LoadingSpinner from '../common/LoadingSpinner';
 
 type IProps = RouteComponentProps<{id: string}>;
 
@@ -87,7 +87,9 @@ class Messages extends Component<IProps & Stores<'messagesStore' | 'appStore'>, 
                         </Button>
                     </div>
                 }>
-                {hasMessages ? (
+                { messagesStore.isLoading(appId) ? ( 
+                    <LoadingSpinner />
+                ) : hasMessages ? (
                     <div style={{width: '100%'}} id="messages">
                         <ReactInfinite
                             key={appId}
@@ -98,9 +100,7 @@ class Messages extends Component<IProps & Stores<'messagesStore' | 'appStore'>, 
                         </ReactInfinite>
 
                         {hasMore ? (
-                            <Grid item xs={12} style={{textAlign: 'center'}}>
-                                <CircularProgress size={100} />
-                            </Grid>
+                            <LoadingSpinner />
                         ) : (
                             this.label("You've reached the end")
                         )}

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -87,7 +87,7 @@ class Messages extends Component<IProps & Stores<'messagesStore' | 'appStore'>, 
                         </Button>
                     </div>
                 }>
-                { messagesStore.isLoading(appId) ? ( 
+                { !messagesStore.loaded(appId) ? (
                     <LoadingSpinner />
                 ) : hasMessages ? (
                     <div style={{width: '100%'}} id="messages">

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -87,7 +87,7 @@ class Messages extends Component<IProps & Stores<'messagesStore' | 'appStore'>, 
                         </Button>
                     </div>
                 }>
-                { !messagesStore.loaded(appId) ? (
+                {!messagesStore.loaded(appId) ? (
                     <LoadingSpinner />
                 ) : hasMessages ? (
                     <div style={{width: '100%'}} id="messages">
@@ -99,11 +99,7 @@ class Messages extends Component<IProps & Stores<'messagesStore' | 'appStore'>, 
                             {messages.map(this.renderMessage)}
                         </ReactInfinite>
 
-                        {hasMore ? (
-                            <LoadingSpinner />
-                        ) : (
-                            this.label("You've reached the end")
-                        )}
+                        {hasMore ? <LoadingSpinner /> : this.label("You've reached the end")}
                     </div>
                 ) : (
                     this.label('No messages')

--- a/ui/src/message/MessagesStore.ts
+++ b/ui/src/message/MessagesStore.ts
@@ -13,12 +13,13 @@ interface MessagesState {
     hasMore: boolean;
     nextSince: number;
     loaded: boolean;
-    isLoading: boolean,
 }
 
 export class MessagesStore {
     @observable
     private state: Record<string, MessagesState> = {};
+
+    private loading = false;
 
     public constructor(
         private readonly appStore: BaseStore<IApplication>,
@@ -34,17 +35,17 @@ export class MessagesStore {
         return this.state[appId] || this.emptyState();
     };
 
-    public isLoading = (appId: number) => this.stateOf(appId, /*create*/ false).isLoading
+    public loaded = (appId: number) => this.stateOf(appId, /*create*/ false).loaded;
 
     public canLoadMore = (appId: number) => this.stateOf(appId, /*create*/ false).hasMore;
 
     @action
     public loadMore = async (appId: number) => {
         const state = this.stateOf(appId);
-        if (!state.hasMore || state.isLoading) {
+        if (!state.hasMore || this.loading) {
             return Promise.resolve();
         }
-        state.isLoading = true;
+        this.loading = true;
 
         const pagedResult = await this.fetchMessages(appId, state.nextSince).then(
             (resp) => resp.data
@@ -54,7 +55,7 @@ export class MessagesStore {
         state.nextSince = pagedResult.paging.since ?? 0;
         state.hasMore = 'next' in pagedResult.paging;
         state.loaded = true;
-        state.isLoading = false;
+        this.loading = false;
         return Promise.resolve();
     };
 
@@ -160,6 +161,5 @@ export class MessagesStore {
         hasMore: true,
         nextSince: 0,
         loaded: false,
-        isLoading: false,
     });
 }


### PR DESCRIPTION
This PR adds loading animations to the application panels when loading messages, instead of just showing "no messages". I've used the already existing `LoadingSpinner` component for this.

Hint: This PR also changes the size of the `LoadingSpinner` from 150 to 40 (used after login and (since now) on message load). This looks way more modern in my opinion. Feel free to revert the last commit of this PR if you disagree.

Closes #658 