### PR TITLE
Add bump-go action

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -1,0 +1,23 @@
+name: Bump Go Version
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 5 * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  try-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Bump Go Version
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Open a PR if not up to date
+        run: ci/bump-go.sh

--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -5,7 +5,7 @@ on:
   - cron: '0 5 * * *'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/ci/bump_go.sh
+++ b/ci/bump_go.sh
@@ -6,6 +6,11 @@ PR_LABEL="bump-go"
 
 set -e
 
+if [ ! -z "$(git status -s -uall)" ]; then
+    echo "Working directory is not clean" 2>&1
+    exit 1
+fi
+
 git show-ref --verify --quiet refs/heads/bump-go || git branch -c $REF_BRANCH bump-go
 
 # The version in the GO_VERSION file
@@ -20,7 +25,7 @@ echo "Installed version: $latest_version"
 bump_candidate_version=$(git show bump-go:GO_VERSION 2>/dev/null || echo "")
 echo "Bump candidate version: $bump_candidate_version"
 
-existing_prs=$(gh pr list --state open --base main --label "$PR_KEYWORD" --json "number" | jq -r 'map(.number) | .[]')
+existing_prs=$(gh pr list --state open --base $REF_BRANCH --label "$PR_LABEL" --json "number" | jq -r 'map(.number) | .[]')
 
 if [ "$current_version" == "$latest_version" ]; then
     echo "Go is up to date"

--- a/ci/bump_go.sh
+++ b/ci/bump_go.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+REF_BRANCH=master
+PR_KEYWORD="[bump-go]"
+PR_LABEL="bump-go"
+
+set -e
+
+git show-ref --verify --quiet refs/heads/bump-go || git branch -c $REF_BRANCH bump-go
+
+# The version in the GO_VERSION file
+current_version=$(git show $REF_BRANCH:GO_VERSION 2>/dev/null || echo "")
+echo "Current version: $current_version"
+
+# The latest version installed
+latest_version=$(go version | sed -E 's/.*go([0-9\.]*).*/\1/')
+echo "Installed version: $latest_version"
+
+# The version already open in a PR
+bump_candidate_version=$(git show bump-go:GO_VERSION 2>/dev/null || echo "")
+echo "Bump candidate version: $bump_candidate_version"
+
+existing_prs=$(gh pr list --state open --base main --label "$PR_KEYWORD" --json "number" | jq -r 'map(.number) | .[]')
+
+if [ "$current_version" == "$latest_version" ]; then
+    echo "Go is up to date"
+    exit 0
+elif [ "$latest_version" == "$bump_candidate_version" ] && [ ! -z "$existing_prs" ]; then
+    echo "A PR is already open"
+    exit 0
+fi
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "GITHUB_TOKEN not set, but this is what I would do:"
+    echo "git checkout bump-go && git merge --ff-only $REF_BRANCH"
+    echo "echo \"$latest_version\" > GO_VERSION"
+    echo "git add GO_VERSION"
+    echo "git commit -m \"$PR_KEYWORD Bump Go to $latest_version\""
+    echo "git push origin bump-go"
+    if [ -z "$existing_prs" ]; then
+        echo "gh pr create --base $REF_BRANCH --head bump-go --title \"$PR_KEYWORD Bump Go to $latest_version\" --label \"$PR_LABEL\""
+    else
+        first_id=$(echo "$existing_prs" | head -n 1)
+        echo "gh pr edit $first_id --title \"$PR_KEYWORD Bump Go to $latest_version\""
+    fi
+else
+    git checkout bump-go && git merge --ff-only $REF_BRANCH
+    echo "$latest_version" > GO_VERSION
+    git add GO_VERSION
+    if git diff --quiet --cached; then
+        echo "No changes to commit"
+    else
+        git commit -m "$PR_KEYWORD Bump Go to $latest_version"
+    fi
+    git push origin bump-go
+    if [ -z "$existing_prs" ]; then
+        gh pr create --base $REF_BRANCH --head bump-go --title "$PR_KEYWORD Bump Go to $latest_version" --label "$PR_LABEL" \
+            --body "This PR was automatically created by the bump-go action."
+    else
+        first_id=$(echo "$existing_prs" | head -n 1)
+        gh pr edit $first_id --title "$PR_KEYWORD Bump Go to $latest_version"
+    fi
+fi
+   


### PR DESCRIPTION
Rel: #699

Current logic:

If the stable Go version does not equal GO_VERSION on master and does not equal the version on the bump-go branch then create or update a PR.

Whether to go for a fully automated release I think let's wait and see for maybe 2 cycles and if minimal intervention is required then we can make this automated. I think this should have already taken off a large portion of wasted time for releases which is waiting for CI to finish..

For a fully automated workflow I think the general idea of what to do next is:
- Pull in updates daily if master is updated but this branch is not.
- Detect a review submission and after some sanity checks (no new pushes to master, etc), merge to master and generate a new tag automatically using the current release infrastructure.