### PR TITLE
Docker multiarch image 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ coverage.txt
 data/
 images/
 .git/
+*/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+vendor/
+.idea/
+build/
+licenses/
+coverage.txt
+data/
+images/
+.git/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
       - if: startsWith(github.ref, 'refs/tags/v')
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - if: startsWith(github.ref, 'refs/tags/v')
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export LD_FLAGS="-w -s -X main.Version=$VERSION -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod"
           make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       - if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export LD_FLAGS="-w -s -X main.Version=$VERSION -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod"
+          echo "LD_FLAGS=$LD_FLAGS" >> $GITHUB_ENV
+          
           make build
           sudo chown -R $UID build
           make package-zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,32 +29,32 @@ jobs:
       - if: startsWith(github.ref, 'refs/tags/v')
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - if: startsWith(github.ref, 'refs/tags/v')
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export LD_FLAGS="-w -s -X main.Version=$VERSION -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod"
           make build
           sudo chown -R $UID build
           make package-zip
           ls -lath build
-          make build-docker
-          docker image ls
-          echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
-          echo "$DOCKER_GHCR_PASS" | docker login ghcr.io --username "$DOCKER_GHCR_USER" --password-stdin
-          docker push --all-tags gotify/server
-          docker push --all-tags gotify/server-arm7
-          docker push --all-tags gotify/server-arm64
-          docker push --all-tags gotify/server-riscv64
-          docker push --all-tags ghcr.io/gotify/server
-          docker push --all-tags ghcr.io/gotify/server-arm7
-          docker push --all-tags ghcr.io/gotify/server-arm64
-          docker push --all-tags ghcr.io/gotify/server-riscv64
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-          DOCKER_GHCR_USER: ${{ secrets.DOCKER_GHCR_USER }}
-          DOCKER_GHCR_PASS: ${{ secrets.DOCKER_GHCR_PASS }}
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - if: startsWith(github.ref, 'refs/tags/v')
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+      - if: startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_GHCR_USER }}
+          password: ${{ secrets.DOCKER_GHCR_PASS }}
+      - if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          make DOCKER_BUILD_PUSH=true build-docker 
       - if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.DOCKER_GHCR_PASS }}
       - if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          make DOCKER_BUILD_PUSH=true build-docker 
+          make DOCKER_BUILD_PUSH=true build-docker
       - if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ package-zip: extract-licenses
 
 build-docker-multiarch: require-version
 	docker buildx build --sbom=true --provenance=true \
-		--output type=local,dest=container-out \
 		-t gotify/server:latest \
 		-t gotify/server:${VERSION} \
 		-t gotify/server:$(shell echo $(VERSION) | cut -d '.' -f -2) \

--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,6 @@ build-docker-multiarch: require-version
 		--platform linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/riscv64 \
 		-f docker/Dockerfile .
 
-# Backwards compatibility
-build-docker-amd64: build-docker-multiarch
-build-docker-i386: build-docker-multiarch
-build-docker-arm64: build-docker-multiarch
-build-docker-arm-7: build-docker-multiarch
-build-docker-riscv64: build-docker-multiarch
-
 build-docker: build-docker-multiarch
 
 _build_within_docker: OUTPUT = gotify-app

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ package-zip: extract-licenses
 
 build-docker-multiarch: require-version
 	docker buildx build --sbom=true --provenance=true \
+		$(if $(DOCKER_BUILD_PUSH),--push) \
 		-t gotify/server:latest \
 		-t gotify/server:${VERSION} \
 		-t gotify/server:$(shell echo $(VERSION) | cut -d '.' -f -2) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,17 @@
-ARG DEBIAN=stable-slim
-# supprress warnung about invalid variable expansion
+ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
+ARG DEBIAN_STABLE_ARCH=stable-slim
+ARG DEBIAN_EXPERIMENTAL_ARCH=sid-slim
+# suppress warnung about invalid variable expansion
 ARG GO_VERSION=PLEASE_PROVIDE_GO_VERSION
+
+# Hack to normalize platform to match the chosed build image
+# Get the gotify/build image tag
+ARG __TARGETPLATFORM_DASHES=${TARGETPLATFORM/\//-}
+ARG __TARGETPLATFORM_GO_NOTATION=${__TARGETPLATFORM_DASHES/arm\/v7/arm-7}
+# Set the unstable tag if the target platform is not stable
+ARG __TARGETPLATFORM_IS_STABLE=${TARGETPLATFORM/linux\/riscv64/}
+ARG __DEBIAN_HAS_STABLE_TAG=${__TARGETPLATFORM_IS_STABLE/?*/${DEBIAN}} # if the last variable is not empty, set it to the debian stable tag
+ARG DEBIAN=${__DEBIAN_HAS_STABLE_TAG:-${DEBIAN_EXPERIMENTAL_ARCH}} # else set it to the debian experimental tag
 
 # --- JS Builder ---
 
@@ -37,10 +48,12 @@ RUN if [ "$BUILD_JS" = "1" ]; then \
 
 # --- Go Builder ---
 
-FROM --platform=${BUILDPLATFORM} gotify/build:${GO_VERSION}-${TARGETPLATFORM/\//-} AS builder
+FROM --platform=${BUILDPLATFORM} gotify/build:${GO_VERSION}-${__TARGETPLATFORM_GO_NOTATION} AS builder
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 ARG BUILD_JS=0
-ARG RUN_TESTS=0
+ARG RUN_TESTS=0 # 0=never, 1=native only
 ARG GO_BUILD_FLAGS=-mod=readonly -a -installsuffix cgo
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -57,7 +70,9 @@ RUN if [ "$BUILD_JS" = "1" ]; then \
 
 RUN cd /src/gotify && \
     mkdir -p /target/app && \
-    [ "$RUN_TESTS" = "1" ] && go test -v ./... || true && \
+    if [ "$RUN_TESTS" = "1" ] && [ "$BUILDPLATFORM" = "$TARGETPLATFORM" ]; then \
+    go test -v ./...; \
+    fi && \
     go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app
 
 FROM debian:${DEBIAN}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG BUILD_JS=0
 ARG RUN_TESTS=0 # 0=never, 1=native only
-ARG GO_BUILD_FLAGS=-mod=readonly -a -installsuffix cgo
+ARG LD_FLAGS=""
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
@@ -73,13 +73,12 @@ RUN cd /src/gotify && \
     if [ "$RUN_TESTS" = "1" ] && [ "$BUILDPLATFORM" = "$TARGETPLATFORM" ]; then \
     go test -v ./...; \
     fi && \
-    go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app
+    LD_FLAGS=${LD_FLAGS} make OUTPUT=/target/gotify-app _build_within_docker
 
 FROM debian:${DEBIAN}
 
 # build-time configurables
 ARG GOTIFY_SERVER_EXPOSE=80
-ARG GOTIFY_UID=0
 ENV GOTIFY_SERVER_PORT=$GOTIFY_SERVER_EXPOSE
 
 WORKDIR /app
@@ -88,13 +87,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
     tzdata \
     curl \
     ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && \
-    if [ "$GOTIFY_UID" != "0" ]; then \
-    useradd -u $GOTIFY_UID -r gotify && \
-    chown gotify:gotify /app; \
-    fi
-
-USER $GOTIFY_UID
+    rm -rf /var/lib/apt/lists/*
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
 EXPOSE $GOTIFY_SERVER_EXPOSE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,21 +15,14 @@ ARG DEBIAN=${__DEBIAN_HAS_STABLE_TAG:-${DEBIAN_EXPERIMENTAL_ARCH}} # else set it
 
 # --- JS Builder ---
 
-FROM --platform=${BUILDPLATFORM} debian:${DEBIAN} AS js-builder
+FROM --platform=${BUILDPLATFORM} node:23 AS js-builder
 
 ARG BUILD_JS=0
 ARG NODE_OPTIONS
-ENV DEBIAN_FRONTEND=noninteractive
 
 COPY . /src/gotify
 
 RUN if [ "$BUILD_JS" = "1" ]; then \
-    apt-get update && apt-get install -yq --no-install-recommends \
-    curl \
-    git \
-    nodejs \
-    npm && \
-    \
     NODE_OPTIONS_DEFAULT=$(if node --help | grep -q -- "--openssl-legacy-provider"; then echo --openssl-legacy-provider; fi) && \
     export NODE_OPTIONS=${NODE_OPTIONS:-$NODE_OPTIONS_DEFAULT} && \
     echo "Using NODE_OPTIONS=$NODE_OPTIONS" && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG __TARGETPLATFORM_DASHES=${TARGETPLATFORM/\//-}
 ARG __TARGETPLATFORM_GO_NOTATION=${__TARGETPLATFORM_DASHES/arm\/v7/arm-7}
 # Set the unstable tag if the target platform is not stable
 ARG __TARGETPLATFORM_IS_STABLE=${TARGETPLATFORM/linux\/riscv64/}
-ARG __DEBIAN_HAS_STABLE_TAG=${__TARGETPLATFORM_IS_STABLE/?*/${DEBIAN}} # if the last variable is not empty, set it to the debian stable tag
+ARG __DEBIAN_HAS_STABLE_TAG=${__TARGETPLATFORM_IS_STABLE/?*/${DEBIAN_STABLE_ARCH}} # if the last variable is not empty, set it to the debian stable tag
 ARG DEBIAN=${__DEBIAN_HAS_STABLE_TAG:-${DEBIAN_EXPERIMENTAL_ARCH}} # else set it to the debian experimental tag
 
 # --- JS Builder ---

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
-# suppress warnung about invalid variable expansion
+# Suppress warning about invalid variable expansion
 ARG GO_VERSION=PLEASE_PROVIDE_GO_VERSION
 ARG DEBIAN=sid-slim
 
@@ -54,7 +54,7 @@ RUN cd /src/gotify && \
 
 FROM debian:${DEBIAN}
 
-# build-time configurables
+# Build-time configurables
 ARG GOTIFY_SERVER_EXPOSE=80
 ENV GOTIFY_SERVER_PORT=$GOTIFY_SERVER_EXPOSE
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,87 @@
-FROM amd64/debian:stable-slim
-ENV GOTIFY_SERVER_PORT="80"
+ARG DEBIAN=stable
+
+# --- JS Builder ---
+
+FROM debian:${DEBIAN} AS js-builder
+
+ARG BUILD_JS=1
+ARG NODE_OPTIONS
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY . /src/gotify
+
+RUN if [ "$BUILD_JS" = "1" ]; then \
+    apt-get update && apt-get install -yq --no-install-recommends \
+    curl \
+    git \
+    nodejs \
+    npm && \
+    \
+    NODE_OPTIONS_DEFAULT=$(if node --help | grep -q -- "--openssl-legacy-provider"; then echo --openssl-legacy-provider; fi) && \
+    export NODE_OPTIONS=${NODE_OPTIONS:-$NODE_OPTIONS_DEFAULT} && \
+    echo "Using NODE_OPTIONS=$NODE_OPTIONS" && \
+    cd /src/gotify/ui && \
+    \
+    npm install -g yarn && \
+    \
+    yarn install && \
+    yarn build && \
+    \
+    cp -r /src/gotify/ui/build /target; \
+    \
+    else \
+    mkdir -p /target; \
+    fi
+
+# --- Go Builder ---
+
+FROM debian:${DEBIAN} AS builder
+
+ARG BUILD_JS=1
+ARG GO_BUILD_FLAGS=-mod=readonly -a -installsuffix cgo
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD https://raw.githubusercontent.com/travis-ci/gimme/master/gimme /usr/local/bin/gimme 
+
+RUN chmod +x /usr/local/bin/gimme # compatiblity
+
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git
+
+COPY . /src/gotify
+COPY --from=js-builder /target /ui-build
+
+RUN if [ "$BUILD_JS" = "1" ]; then \
+    cp -r --update /ui-build /src/gotify/ui/build; \
+    fi
+
+RUN cd /src/gotify && \
+    read -r GIMME_GO_VERSION < GO_VERSION && \
+    echo "Using Go version: $GIMME_GO_VERSION" && \
+    gimme ${GIMME_GO_VERSION} && \
+    mkdir -p /target/app && \
+    bash -c ". ~/.gimme/envs/go${GIMME_GO_VERSION}.env && go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app"
+
+FROM debian:${DEBIAN}-slim
+
+# build-time configurable port
+ARG GOTIFY_SERVER_EXPOSE=80
+ENV GOTIFY_SERVER_PORT=$GOTIFY_SERVER_EXPOSE
+
 WORKDIR /app
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq \
-  tzdata \
-  curl \
-  ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-ADD gotify-app /app/
+
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq --no-install-recommends \
+    tzdata \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
-EXPOSE 80
+EXPOSE $GOTIFY_SERVER_EXPOSE
+
+COPY --from=builder /target /
+
 ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEBIAN=stable
+ARG DEBIAN=stable-slim
 
 # --- JS Builder ---
 
@@ -38,6 +38,7 @@ RUN if [ "$BUILD_JS" = "1" ]; then \
 FROM debian:${DEBIAN} AS builder
 
 ARG BUILD_JS=1
+ARG RUN_TESTS=1
 ARG GO_BUILD_FLAGS=-mod=readonly -a -installsuffix cgo
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -63,12 +64,13 @@ RUN cd /src/gotify && \
     echo "Using Go version: $GIMME_GO_VERSION" && \
     gimme ${GIMME_GO_VERSION} && \
     mkdir -p /target/app && \
-    bash -c ". ~/.gimme/envs/go${GIMME_GO_VERSION}.env && go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app"
+    bash -c ". ~/.gimme/envs/go${GIMME_GO_VERSION}.env && go test -v ./... && go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app"
 
-FROM debian:${DEBIAN}-slim
+FROM debian:${DEBIAN}
 
-# build-time configurable port
+# build-time configurables
 ARG GOTIFY_SERVER_EXPOSE=80
+ARG GOTIFY_UID=0
 ENV GOTIFY_SERVER_PORT=$GOTIFY_SERVER_EXPOSE
 
 WORKDIR /app
@@ -76,8 +78,14 @@ WORKDIR /app
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -yq --no-install-recommends \
     tzdata \
     curl \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    if [ "$GOTIFY_UID" != "0" ]; then \
+    useradd -u $GOTIFY_UID -r gotify && \
+    chown gotify:gotify /app; \
+    fi
+
+USER $GOTIFY_UID
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD curl --fail http://localhost:$GOTIFY_SERVER_PORT/health || exit 1
 EXPOSE $GOTIFY_SERVER_EXPOSE

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,12 @@
 ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
-ARG DEBIAN_STABLE_ARCH=stable-slim
-ARG DEBIAN_EXPERIMENTAL_ARCH=sid-slim
 # suppress warnung about invalid variable expansion
 ARG GO_VERSION=PLEASE_PROVIDE_GO_VERSION
+ARG DEBIAN=sid-slim
 
 # Hack to normalize platform to match the chosed build image
 # Get the gotify/build image tag
 ARG __TARGETPLATFORM_DASHES=${TARGETPLATFORM/\//-}
 ARG __TARGETPLATFORM_GO_NOTATION=${__TARGETPLATFORM_DASHES/arm\/v7/arm-7}
-# Set the unstable tag if the target platform is not stable
-ARG __TARGETPLATFORM_IS_STABLE=${TARGETPLATFORM/linux\/riscv64/}
-ARG __DEBIAN_HAS_STABLE_TAG=${__TARGETPLATFORM_IS_STABLE/?*/${DEBIAN_STABLE_ARCH}} # if the last variable is not empty, set it to the debian stable tag
-ARG DEBIAN=${__DEBIAN_HAS_STABLE_TAG:-${DEBIAN_EXPERIMENTAL_ARCH}} # else set it to the debian experimental tag
 
 # --- JS Builder ---
 
@@ -66,7 +61,7 @@ RUN cd /src/gotify && \
     if [ "$RUN_TESTS" = "1" ] && [ "$BUILDPLATFORM" = "$TARGETPLATFORM" ]; then \
     go test -v ./...; \
     fi && \
-    LD_FLAGS=${LD_FLAGS} make OUTPUT=/target/gotify-app _build_within_docker
+    LD_FLAGS=${LD_FLAGS} make OUTPUT=/target/app/gotify-app _build_within_docker
 
 FROM debian:${DEBIAN}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,25 +13,15 @@ ARG __TARGETPLATFORM_GO_NOTATION=${__TARGETPLATFORM_DASHES/arm\/v7/arm-7}
 FROM --platform=${BUILDPLATFORM} node:23 AS js-builder
 
 ARG BUILD_JS=0
-ARG NODE_OPTIONS
 
-COPY . /src/gotify
+COPY ./Makefile /src/gotify/Makefile
+COPY ./ui /src/gotify/ui
 
 RUN if [ "$BUILD_JS" = "1" ]; then \
-    NODE_OPTIONS_DEFAULT=$(if node --help | grep -q -- "--openssl-legacy-provider"; then echo --openssl-legacy-provider; fi) && \
-    export NODE_OPTIONS=${NODE_OPTIONS:-$NODE_OPTIONS_DEFAULT} && \
-    echo "Using NODE_OPTIONS=$NODE_OPTIONS" && \
-    cd /src/gotify/ui && \
-    \
-    npm install -g yarn && \
-    \
-    yarn install && \
-    yarn build && \
-    \
-    cp -r /src/gotify/ui/build /target; \
-    \
+    (cd /src/gotify/ui && yarn install) && \
+    (cd /src/gotify && make build-js) \
     else \
-    mkdir -p /target; \
+    mkdir -p /src/gotify/ui/build; \
     fi
 
 # --- Go Builder ---
@@ -50,14 +40,13 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     git
 
 COPY . /src/gotify
-COPY --from=js-builder /target /ui-build
+COPY --from=js-builder /src/gotify/ui/build /ui-build
 
 RUN if [ "$BUILD_JS" = "1" ]; then \
     cp -r --update /ui-build /src/gotify/ui/build; \
     fi
 
 RUN cd /src/gotify && \
-    mkdir -p /target/app && \
     if [ "$RUN_TESTS" = "1" ] && [ "$BUILDPLATFORM" = "$TARGETPLATFORM" ]; then \
     go test -v ./...; \
     fi && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,12 @@
 ARG DEBIAN=stable-slim
+# supprress warnung about invalid variable expansion
+ARG GO_VERSION=PLEASE_PROVIDE_GO_VERSION
 
 # --- JS Builder ---
 
-FROM debian:${DEBIAN} AS js-builder
+FROM --platform=${BUILDPLATFORM} debian:${DEBIAN} AS js-builder
 
-ARG BUILD_JS=1
+ARG BUILD_JS=0
 ARG NODE_OPTIONS
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -35,21 +37,15 @@ RUN if [ "$BUILD_JS" = "1" ]; then \
 
 # --- Go Builder ---
 
-FROM debian:${DEBIAN} AS builder
+FROM --platform=${BUILDPLATFORM} gotify/build:${GO_VERSION}-${TARGETPLATFORM/\//-} AS builder
 
-ARG BUILD_JS=1
-ARG RUN_TESTS=1
+ARG BUILD_JS=0
+ARG RUN_TESTS=0
 ARG GO_BUILD_FLAGS=-mod=readonly -a -installsuffix cgo
 ENV DEBIAN_FRONTEND=noninteractive
 
-ADD https://raw.githubusercontent.com/travis-ci/gimme/master/gimme /usr/local/bin/gimme 
-
-RUN chmod +x /usr/local/bin/gimme # compatiblity
-
 RUN apt-get update && apt-get install -yq --no-install-recommends \
-    build-essential \
     ca-certificates \
-    curl \
     git
 
 COPY . /src/gotify
@@ -60,11 +56,9 @@ RUN if [ "$BUILD_JS" = "1" ]; then \
     fi
 
 RUN cd /src/gotify && \
-    read -r GIMME_GO_VERSION < GO_VERSION && \
-    echo "Using Go version: $GIMME_GO_VERSION" && \
-    gimme ${GIMME_GO_VERSION} && \
     mkdir -p /target/app && \
-    bash -c ". ~/.gimme/envs/go${GIMME_GO_VERSION}.env && go test -v ./... && go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app"
+    [ "$RUN_TESTS" = "1" ] && go test -v ./... || true && \
+    go build ${GO_BUILD_FLAGS} -o /target/app/gotify-app
 
 FROM debian:${DEBIAN}
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,5 +1,0 @@
-FROM arm64v8/debian
-WORKDIR /app
-ADD gotify-app /app/
-EXPOSE 80
-ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile.armv7
+++ b/docker/Dockerfile.armv7
@@ -1,5 +1,0 @@
-FROM arm32v7/debian:stable-slim
-WORKDIR /app
-ADD gotify-app /app/
-EXPOSE 80
-ENTRYPOINT ["./gotify-app"]

--- a/docker/Dockerfile.riscv64
+++ b/docker/Dockerfile.riscv64
@@ -1,5 +1,0 @@
-FROM riscv64/debian:sid-slim
-WORKDIR /app
-ADD gotify-app /app/
-EXPOSE 80
-ENTRYPOINT ["./gotify-app"]

--- a/test/filepath_test.go
+++ b/test/filepath_test.go
@@ -32,9 +32,11 @@ func TestWithWd(t *testing.T) {
 	})
 
 	assert.Nil(t, os.Mkdir(tmpDir.Path(), 0o644))
-	assert.Panics(t, func() {
-		WithWd(tmpDir.Path(), func(string) {})
-	})
+	if os.Getuid() != 0 { // root is not subject to this check
+		assert.Panics(t, func() {
+			WithWd(tmpDir.Path(), func(string) {})
+		})
+	}
 	assert.Nil(t, os.Remove(tmpDir.Path()))
 
 	assert.Nil(t, os.Mkdir(tmpDir.Path(), 0o755))


### PR DESCRIPTION
fixes #257 .
fixes #350 

Simply `make build-docker-multiarch` and then `docker run` should work. I implemented building JS from docker as well but opt-in, just for people who want's to build a usable local container without having to do anything outside of docker.

Current blockers: (nevermind I had a nap and figured out how to do it)


The last step of installing runtime dependency need qemu, it's not easy to get around that unfortunately 