### PR TITLE
Wait for some time for the client list to update

### DIFF
--- a/ui/src/tests/application.test.ts
+++ b/ui/src/tests/application.test.ts
@@ -28,10 +28,10 @@ const hiddenToken = '•••••••••••••••';
 const $table = selector.table('#app-table');
 const $dialog = selector.form('#app-dialog');
 
-const hasApp =
+const waitforApp =
     (name: string, description: string, row: number): (() => Promise<void>) =>
     async () => {
-        expect(await innerText(page, $table.cell(row, Col.Name))).toBe(name);
+        await waitForExists(page, $table.cell(row, Col.Name), name);
         expect(await innerText(page, $table.cell(row, Col.Token))).toBe(hiddenToken);
         expect(await innerText(page, $table.cell(row, Col.Description))).toBe(description);
     };
@@ -87,9 +87,9 @@ describe('Application', () => {
             await page.waitForSelector($table.row(3));
             expect(await count(page, $table.rows())).toBe(3);
         });
-        it('has server app', hasApp('server', '#1', 1));
-        it('has desktop app', hasApp('desktop', '#2', 2));
-        it('has raspberry app', hasApp('raspberry', '#3', 3));
+        it('has server app', waitforApp('server', '#1', 1));
+        it('has desktop app', waitforApp('desktop', '#2', 2));
+        it('has raspberry app', waitforApp('raspberry', '#3', 3));
         it('shows token', async () => {
             await page.click($table.cell(3, Col.Token, '.toggle-visibility'));
             const token = await innerText(page, $table.cell(3, Col.Token));
@@ -103,9 +103,9 @@ describe('Application', () => {
         await updateApp(3, {name: 'raspberry_pi', description: 'home_pi'})();
     });
     it('has updated application', async () => {
-        await hasApp('server_linux', '#1', 1)();
-        await hasApp('desktop', 'kitchen_computer', 2)();
-        await hasApp('raspberry_pi', 'home_pi', 3)();
+        await waitforApp('server_linux', '#1', 1)();
+        await waitforApp('desktop', 'kitchen_computer', 2)();
+        await waitforApp('raspberry_pi', 'home_pi', 3)();
     });
     it('deletes application', async () => {
         await page.click($table.cell(2, Col.EditDelete, '.delete'));

--- a/ui/src/tests/client.test.ts
+++ b/ui/src/tests/client.test.ts
@@ -22,10 +22,10 @@ enum Col {
     Delete = 5,
 }
 
-const hasClient =
+const waitForClient =
     (name: string, row: number): (() => Promise<void>) =>
     async () => {
-        expect(await innerText(page, $table.cell(row, Col.Name))).toBe(name);
+        await waitForExists(page, $table.cell(row, Col.Name), name);
     };
 
 const updateClient =
@@ -79,7 +79,7 @@ describe('Client', () => {
         expect(await innerText(page, $table.cell(3, Col.Name))).toBe('desktop app');
     });
     it('updates client', updateClient(1, {name: 'firefox'}));
-    it('has updated client name', hasClient('firefox', 1));
+    it('has updated client name', waitForClient('firefox', 1));
     it('shows token', async () => {
         await page.click($table.cell(3, Col.Token, '.toggle-visibility'));
         expect((await innerText(page, $table.cell(3, Col.Token))).startsWith('C')).toBeTruthy();


### PR DESCRIPTION
All the renovate PR merges failed CI for this issue, seems like if you merge one and too many PRs get updated by renovated at the same time performance slows and there is a delay in the client table being updated

Signed-off-by: eternal-flame-AD <yume@yumechi.jp>