### PR TITLE
renovate: run go mod tidy after renovate update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,5 +44,8 @@
       "groupName": "Bump Go dependencies",
       "groupSlug": "bump-dependencies-go"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
Removes stale entries from go.mod

Signed-off-by: eternal-flame-AD <yume@yumechi.jp>