### PR TITLE
fix: panic when setting bool via envvar

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,15 +16,15 @@ type Configuration struct {
 		Port                   int    `default:"80"`
 
 		SSL struct {
-			Enabled         *bool  `default:"false"`
-			RedirectToHTTPS *bool  `default:"true"`
+			Enabled         bool   `default:"false"`
+			RedirectToHTTPS bool   `default:"true"`
 			ListenAddr      string `default:""`
 			Port            int    `default:"443"`
 			CertFile        string `default:""`
 			CertKey         string `default:""`
 			LetsEncrypt     struct {
-				Enabled   *bool  `default:"false"`
-				AcceptTOS *bool  `default:"false"`
+				Enabled   bool   `default:"false"`
+				AcceptTOS bool   `default:"false"`
 				Cache     string `default:"data/certs"`
 				Hosts     []string
 			}

--- a/router/router.go
+++ b/router/router.go
@@ -41,7 +41,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	g.Use(gin.LoggerWithFormatter(logFormatter), gin.Recovery(), gerror.Handler(), location.Default())
 	g.NoRoute(gerror.NotFound())
 
-	if conf.Server.SSL.Enabled != nil && conf.Server.SSL.RedirectToHTTPS != nil && *conf.Server.SSL.Enabled && *conf.Server.SSL.RedirectToHTTPS {
+	if conf.Server.SSL.Enabled && conf.Server.SSL.RedirectToHTTPS {
 		g.Use(func(ctx *gin.Context) {
 			if ctx.Request.TLS != nil {
 				ctx.Next()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -28,8 +28,8 @@ func Run(router http.Handler, conf *config.Configuration) error {
 	defer httpListener.Close()
 
 	s := &http.Server{Handler: router}
-	if *conf.Server.SSL.Enabled {
-		if *conf.Server.SSL.LetsEncrypt.Enabled {
+	if conf.Server.SSL.Enabled {
+		if conf.Server.SSL.LetsEncrypt.Enabled {
 			applyLetsEncrypt(s, conf)
 		}
 
@@ -93,7 +93,7 @@ func getNetworkAndAddr(listenAddr string, port int) (string, string) {
 
 func applyLetsEncrypt(s *http.Server, conf *config.Configuration) {
 	certManager := autocert.Manager{
-		Prompt:     func(tosURL string) bool { return *conf.Server.SSL.LetsEncrypt.AcceptTOS },
+		Prompt:     func(tosURL string) bool { return conf.Server.SSL.LetsEncrypt.AcceptTOS },
 		HostPolicy: autocert.HostWhitelist(conf.Server.SSL.LetsEncrypt.Hosts...),
 		Cache:      autocert.DirCache(conf.Server.SSL.LetsEncrypt.Cache),
 	}


### PR DESCRIPTION
Don't know exactly what the problem is, but not having pointers for the booleans seem to help and they seem unnecessary. 

    $ docker run -e GOTIFY_SERVER_SSL_ENABLED=true --rm gotify/server:2.6.0
    Starting Gotify version 2.6.0@2024-11-15-19:19:19
    panic: reflect.Set: value of type bool is not assignable to type *bool

    goroutine 1 [running]:
    reflect.Value.assignTo({0xf5e000?, 0x1c375a8?, 0x19?}, {0x108809b, 0xb}, 0xf42960, 0x0)
            /usr/local/go/src/reflect/value.go:3358 +0x299
    reflect.Value.Set({0xf42960?, 0xc0000cd200?, 0x4?}, {0xf5e000?, 0x1c375a8?, 0xf42960?})
            /usr/local/go/src/reflect/value.go:2313 +0xe6
    github.com/jinzhu/configor.(*Configor).processTags(0xc0002f0270, {0xc0002eecc0?, 0xc0000cd200?}, {0xc0002ef0c0, 0x3, 0x4})
            /go/pkg/mod/github.com/jinzhu/configor@v1.2.2/utils.go:307 +0xc11
    github.com/jinzhu/configor.(*Configor).processTags(0xc0002f0270, {0xc0002eec80?, 0xc0000cd1e0?}, {0xc0002ad880, 0x2, 0x2})
            /go/pkg/mod/github.com/jinzhu/configor@v1.2.2/utils.go:330 +0xe79
    github.com/jinzhu/configor.(*Configor).processTags(0xc0002f0270, {0xf41420?, 0xc0000cd1e0?}, {0xc0002f0610, 0x1, 0x1})
            /go/pkg/mod/github.com/jinzhu/configor@v1.2.2/utils.go:330 +0xe79
    github.com/jinzhu/configor.(*Configor).load(0xc0002f0270, {0xf41420, 0xc0000cd1e0}, 0x0, {0xc0002ad7a0?, 0x1c7c000?, 0xc0002ad7a0?})
            /go/pkg/mod/github.com/jinzhu/configor@v1.2.2/utils.go:415 +0x3f8
    github.com/jinzhu/configor.(*Configor).Load(0xc0002f0270, {0xf41420, 0xc0000cd1e0}, {0xc0002ad7a0, 0x2, 0x2})
            /go/pkg/mod/github.com/jinzhu/configor@v1.2.2/configor.go:92 +0x13c
    github.com/gotify/server/v2/config.Get()
            /src/gotify/config/config.go:69 +0xf3
    main.main()
            /src/gotify/app.go:34 +0x1e5

See https://github.com/gotify/server/issues/731#issuecomment-2479974046

Is an upstream issue: https://github.com/jinzhu/configor/issues/92