### PR TITLE
Cleaner authority of go version update (go -> gotify/build -> go.mod + GO_VERSION)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ LICENSE_DIR=./licenses/
 BUILD_DIR=./build
 DOCKER_DIR=./docker/
 SHELL := /bin/bash
-GO_VERSION=`cat GO_VERSION`
+ifndef GOTOOLCHAIN
+	GO_VERSION=$(GOTOOLCHAIN)
+else
+	GO_VERSION=$(shell go mod edit -json | jq -r .Toolchain | sed -e 's/go//')
+endif
 DOCKER_BUILD_IMAGE=gotify/build
 DOCKER_WORKDIR=/proj
 DOCKER_RUN=docker run --rm -e LD_FLAGS="$$LD_FLAGS" -v "$$PWD/.:${DOCKER_WORKDIR}" -v "`go env GOPATH`/pkg/mod/.:/go/pkg/mod:ro" -w ${DOCKER_WORKDIR}
@@ -100,7 +104,7 @@ build-docker-multiarch: require-version
 		-t ghcr.io/gotify/server-riscv64:$(shell echo $(VERSION) | cut -d '.' -f -2) \
 		-t ghcr.io/gotify/server-riscv64:$(shell echo $(VERSION) | cut -d '.' -f -1) \
 		--build-arg RUN_TESTS=$(DOCKER_TEST_LEVEL) \
-		--build-arg GO_VERSION=$(shell cat GO_VERSION) \
+		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg LD_FLAGS="$$LD_FLAGS" \
 		--platform linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/riscv64 \
 		-f docker/Dockerfile .

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,25 @@
       "autoReplaceStringTemplate": "{{{newValue}}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^go.mod$"
+      ],
+      "depTypeTemplate": "language",
+      "matchStrings": [
+        "toolchain go(?<currentValue>[0-9.]+)\\n"
+      ],
+      "extractVersionTemplate": "^(?<version>.+)-linux-amd64$",
+      "depNameTemplate": "docker.io/gotify/build",
+      "autoReplaceStringTemplate": "toolchain go{{{newValue}}}\n",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
+  ],
+  "ignoreDeps": [
+    "go"
   ],
   "packageRules": [
     {
@@ -43,6 +61,13 @@
       ],
       "groupName": "Bump Go dependencies",
       "groupSlug": "bump-dependencies-go"
+    },
+    {
+      "matchDepNames": [
+        "github.com/gotify/build"
+      ],
+      "groupName": "Bump gotify/build",
+      "groupSlug": "bump-gotify-build"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Fixes #779 

Now go version updates gets reported as one PR that update both GO_VERSION and go.mod file pulled from gotify/build and not official go release, so that further builds have consistent toolchain version regardless of whether `go` is used directly or through docker.

I tested the dependency extraction and grouping works locally when manually downgrading the version.