### PR TITLE
fix: skip dotfiles and directories in plugin loading (#811)

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -226,19 +226,28 @@ func (m *Manager) loadPlugins(directory string) error {
 		return fmt.Errorf("error while reading directory %s", err)
 	}
 	for _, f := range pluginFiles {
-		pluginPath := filepath.Join(directory, "./", f.Name())
+		if f.IsDir() {
+			continue
+		}
+
+		name := f.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		pluginPath := filepath.Join(directory, "./", name)
 
 		fmt.Println("Loading plugin", pluginPath)
 		pRaw, err := plugin.Open(pluginPath)
 		if err != nil {
-			return pluginFileLoadError{f.Name(), err}
+			return pluginFileLoadError{name, err}
 		}
 		compatPlugin, err := compat.Wrap(pRaw)
 		if err != nil {
-			return pluginFileLoadError{f.Name(), err}
+			return pluginFileLoadError{name, err}
 		}
 		if err := m.LoadPlugin(compatPlugin); err != nil {
-			return pluginFileLoadError{f.Name(), err}
+			return pluginFileLoadError{name, err}
 		}
 	}
 	return nil

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -147,6 +147,20 @@ func (s *ManagerSuite) TestInitializePlugin_noOpIfEmpty() {
 	assert.Nil(s.T(), s.manager.loadPlugins(""))
 }
 
+func (s *ManagerSuite) TestInitializePlugin_noOpIfDotFile() {
+	tmpDir := test.NewTmpDir("gotify_testinitializeplugin_dotfile")
+	defer tmpDir.Clean()
+	os.Mkdir(tmpDir.Path(".test"), 0o755)
+	assert.Nil(s.T(), s.manager.loadPlugins(tmpDir.Path()))
+}
+
+func (s *ManagerSuite) TestInitializePlugin_noOpIfSubDir() {
+	tmpDir := test.NewTmpDir("gotify_testinitializeplugin_subdir")
+	defer tmpDir.Clean()
+	os.Mkdir(tmpDir.Path("subdir"), 0o755)
+	assert.Nil(s.T(), s.manager.loadPlugins(tmpDir.Path()))
+}
+
 func (s *ManagerSuite) TestInitializePlugin_directoryInvalid_expectError() {
 	assert.Error(s.T(), s.manager.loadPlugins("<<"))
 }

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -150,7 +150,11 @@ func (s *ManagerSuite) TestInitializePlugin_noOpIfEmpty() {
 func (s *ManagerSuite) TestInitializePlugin_noOpIfDotFile() {
 	tmpDir := test.NewTmpDir("gotify_testinitializeplugin_dotfile")
 	defer tmpDir.Clean()
-	os.Mkdir(tmpDir.Path(".test"), 0o755)
+	f, err := os.Create(tmpDir.Path(".test"))
+	assert.NoError(s.T(), err)
+	_, err = f.WriteString("dummy")
+	assert.NoError(s.T(), err)
+	assert.NoError(s.T(), f.Close())
 	assert.Nil(s.T(), s.manager.loadPlugins(tmpDir.Path()))
 }
 


### PR DESCRIPTION
Fixes #811 by ignoring dotfiles and directories in plugin discovery.
