### PR TITLE
fix message layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifdef GOTOOLCHAIN
 else
 	GO_VERSION=$(shell go mod edit -json | jq -r .Toolchain | sed -e 's/go//')
 endif
-DOCKER_BUILD_IMAGE=gotify/build
+DOCKER_BUILD_IMAGE=docker.io/gotify/build
 DOCKER_WORKDIR=/proj
 DOCKER_RUN=docker run --rm -e LD_FLAGS="$$LD_FLAGS" -v "$$PWD/.:${DOCKER_WORKDIR}" -v "`go env GOPATH`/pkg/mod/.:/go/pkg/mod:ro" -w ${DOCKER_WORKDIR}
 DOCKER_GO_BUILD=go build -mod=readonly -a -installsuffix cgo -ldflags "$$LD_FLAGS"

--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -1,4 +1,4 @@
-import {Button, Theme} from '@mui/material';
+import {Button, Theme, useMediaQuery, useTheme} from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import {makeStyles} from 'tss-react/mui';
 import Typography from '@mui/material/Typography';
@@ -33,6 +33,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
     messageContentWrapper: {
         minWidth: 200,
+        width: '100%',
     },
     image: {
         marginRight: 15,
@@ -40,33 +41,13 @@ const useStyles = makeStyles()((theme: Theme) => ({
             width: 32,
             height: 32,
         },
-        [theme.breakpoints.down('sm')]: {
-            display: 'none',
-        },
-    },
-    appName: {
-        opacity: 0.7,
     },
     date: {
         [theme.breakpoints.down('md')]: {
+            order: 1,
+            flexBasis: '100%',
             opacity: 0.7,
         },
-    },
-    messageWrapper: {
-        display: 'grid',
-        gridTemplateColumns: '70px 1fr',
-        [theme.breakpoints.down('sm')]: {
-            gridTemplateColumns: '1fr',
-        },
-        gap: 16,
-        width: '100%',
-    },
-    actionsWrapper: {
-        flex: 1,
-        display: 'flex',
-        justifyContent: 'flex-end',
-        flexDirection: 'row',
-        alignItems: 'flex-start',
     },
     imageWrapper: {
         display: 'flex',
@@ -131,10 +112,12 @@ const Message = ({
     onExpand,
     expanded: initialExpanded,
 }: IProps) => {
+    const theme = useTheme();
     const [previewRef, setPreviewRef] = React.useState<HTMLDivElement | null>(null);
     const {classes} = useStyles();
     const [expanded, setExpanded] = React.useState(initialExpanded);
     const [isOverflowing, setOverflowing] = React.useState(false);
+    const dateWrapped = useMediaQuery(theme.breakpoints.down('md'));
 
     React.useEffect(() => {
         setOverflowing(!!previewRef && previewRef.scrollHeight > previewRef.clientHeight);
@@ -163,73 +146,61 @@ const Message = ({
                     borderLeftWidth: 6,
                     borderLeftStyle: 'solid',
                 }}>
-                <div className={classes.messageWrapper}>
-                    {image !== null ? (
-                        <img
-                            src={config.get('url') + image}
-                            alt={`${appName} logo`}
-                            width="70"
-                            height="70"
-                            className={classes.image}
-                        />
-                    ) : null}
-                    <div style={{width: '100%'}}>
-                        <div style={{display: 'flex', width: '100%'}}>
-                            <div className={classes.messageContentWrapper}>
-                                <div className={classes.header}>
-                                    <Typography
-                                        className={`${classes.headerTitle} title`}
-                                        variant="h5">
-                                        {title}
-                                    </Typography>
-                                </div>
-                                <div className={classes.appName}>
-                                    <Typography variant="body1" className={classes.date}>
-                                        {appName}
-                                    </Typography>
-                                </div>
-                            </div>
-                            <div className={classes.actionsWrapper}>
-                                <Typography variant="body1" className={classes.date}>
-                                    <TimeAgo
-                                        date={date}
-                                        formatter={makeIntlFormatter({
-                                            style: 'narrow',
-                                        })}
-                                    />
-                                </Typography>
-                                <IconButton
-                                    onClick={fDelete}
-                                    className={`${classes.trash} delete`}
-                                    size="large">
-                                    <Delete />
-                                </IconButton>
-                            </div>
-                        </div>
-                        <div>
-                            <Typography
-                                component="div"
-                                ref={setPreviewRef}
-                                className={`${classes.content} content ${
-                                    isOverflowing && expanded ? 'expanded' : ''
-                                }`}>
-                                {renderContent()}
+                <div style={{display: 'flex', width: '100%'}}>
+                    <div className={classes.imageWrapper}>
+                        {image !== null ? (
+                            <img
+                                src={config.get('url') + image}
+                                alt={`${appName} logo`}
+                                width="70"
+                                height="70"
+                                className={classes.image}
+                            />
+                        ) : null}
+                    </div>
+                    <div className={classes.messageContentWrapper}>
+                        <div className={classes.header}>
+                            <Typography className={`${classes.headerTitle} title`} variant="h5">
+                                {title}
                             </Typography>
+                            <Typography variant="body1" className={classes.date}>
+                                <TimeAgo
+                                    date={date}
+                                    formatter={makeIntlFormatter({
+                                        style: dateWrapped ? 'long' : 'narrow',
+                                    })}
+                                />
+                            </Typography>
+                            <IconButton
+                                onClick={fDelete}
+                                className={`${classes.trash} delete`}
+                                size="large">
+                                <Delete />
+                            </IconButton>
                         </div>
-                        {isOverflowing && (
-                            <Button
-                                style={{marginTop: 16}}
-                                onClick={togglePreviewHeight}
-                                variant="contained"
-                                color="primary"
-                                size="large"
-                                fullWidth={true}
-                                startIcon={expanded ? <ExpandLess /> : <ExpandMore />}>
-                                {expanded ? 'Read Less' : 'Read More'}
-                            </Button>
-                        )}
+
+                        <Typography
+                            component="div"
+                            ref={setPreviewRef}
+                            className={`${classes.content} content ${
+                                isOverflowing && expanded ? 'expanded' : ''
+                            }`}>
+                            {renderContent()}
+                        </Typography>
                     </div>
                 </div>
+                {isOverflowing && (
+                    <Button
+                        style={{marginTop: 16}}
+                        onClick={togglePreviewHeight}
+                        variant="contained"
+                        color="primary"
+                        size="large"
+                        fullWidth={true}
+                        startIcon={expanded ? <ExpandLess /> : <ExpandMore />}>
+                        {expanded ? 'Read Less' : 'Read More'}
+                    </Button>
+                )}
             </Container>
         </div>
     );

--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -11,6 +11,7 @@ import {Markdown} from '../common/Markdown';
 import * as config from '../config';
 import {IMessageExtras} from '../types';
 import {contentType, RenderMode} from './extras';
+import {makeIntlFormatter} from 'react-timeago/defaultFormatter';
 
 const PREVIEW_LENGTH = 500;
 
@@ -39,13 +40,33 @@ const useStyles = makeStyles()((theme: Theme) => ({
             width: 32,
             height: 32,
         },
+        [theme.breakpoints.down('sm')]: {
+            display: 'none',
+        },
+    },
+    appName: {
+        opacity: 0.7,
     },
     date: {
         [theme.breakpoints.down('md')]: {
-            order: 1,
-            flexBasis: '100%',
             opacity: 0.7,
         },
+    },
+    messageWrapper: {
+        display: 'grid',
+        gridTemplateColumns: '70px 1fr',
+        [theme.breakpoints.down('sm')]: {
+            gridTemplateColumns: '1fr',
+        },
+        gap: 16,
+        width: '100%',
+    },
+    actionsWrapper: {
+        flex: 1,
+        display: 'flex',
+        justifyContent: 'flex-end',
+        flexDirection: 'row',
+        alignItems: 'flex-start',
     },
     imageWrapper: {
         display: 'flex',
@@ -81,6 +102,7 @@ interface IProps {
     date: string;
     content: string;
     priority: number;
+    appName: string;
     fDelete: VoidFunction;
     extras?: IMessageExtras;
     expanded: boolean;
@@ -105,6 +127,7 @@ const Message = ({
     priority,
     content,
     extras,
+    appName,
     onExpand,
     expanded: initialExpanded,
 }: IProps) => {
@@ -140,56 +163,73 @@ const Message = ({
                     borderLeftWidth: 6,
                     borderLeftStyle: 'solid',
                 }}>
-                <div style={{display: 'flex', width: '100%'}}>
-                    <div className={classes.imageWrapper}>
-                        {image !== null ? (
-                            <img
-                                src={config.get('url') + image}
-                                alt="app logo"
-                                width="70"
-                                height="70"
-                                className={classes.image}
-                            />
-                        ) : null}
-                    </div>
-                    <div className={classes.messageContentWrapper}>
-                        <div className={classes.header}>
-                            <Typography className={`${classes.headerTitle} title`} variant="h5">
-                                {title}
-                            </Typography>
-                            <Typography variant="body1" className={classes.date}>
-                                <TimeAgo date={date} />
-                            </Typography>
-                            <IconButton
-                                onClick={fDelete}
-                                className={`${classes.trash} delete`}
-                                size="large">
-                                <Delete />
-                            </IconButton>
+                <div className={classes.messageWrapper}>
+                    {image !== null ? (
+                        <img
+                            src={config.get('url') + image}
+                            alt={`${appName} logo`}
+                            width="70"
+                            height="70"
+                            className={classes.image}
+                        />
+                    ) : null}
+                    <div style={{width: '100%'}}>
+                        <div style={{display: 'flex', width: '100%'}}>
+                            <div className={classes.messageContentWrapper}>
+                                <div className={classes.header}>
+                                    <Typography
+                                        className={`${classes.headerTitle} title`}
+                                        variant="h5">
+                                        {title}
+                                    </Typography>
+                                </div>
+                                <div className={classes.appName}>
+                                    <Typography variant="body1" className={classes.date}>
+                                        {appName}
+                                    </Typography>
+                                </div>
+                            </div>
+                            <div className={classes.actionsWrapper}>
+                                <Typography variant="body1" className={classes.date}>
+                                    <TimeAgo
+                                        date={date}
+                                        formatter={makeIntlFormatter({
+                                            style: 'narrow',
+                                        })}
+                                    />
+                                </Typography>
+                                <IconButton
+                                    onClick={fDelete}
+                                    className={`${classes.trash} delete`}
+                                    size="large">
+                                    <Delete />
+                                </IconButton>
+                            </div>
                         </div>
-
-                        <Typography
-                            component="div"
-                            ref={setPreviewRef}
-                            className={`${classes.content} content ${
-                                isOverflowing && expanded ? 'expanded' : ''
-                            }`}>
-                            {renderContent()}
-                        </Typography>
+                        <div>
+                            <Typography
+                                component="div"
+                                ref={setPreviewRef}
+                                className={`${classes.content} content ${
+                                    isOverflowing && expanded ? 'expanded' : ''
+                                }`}>
+                                {renderContent()}
+                            </Typography>
+                        </div>
+                        {isOverflowing && (
+                            <Button
+                                style={{marginTop: 16}}
+                                onClick={togglePreviewHeight}
+                                variant="contained"
+                                color="primary"
+                                size="large"
+                                fullWidth={true}
+                                startIcon={expanded ? <ExpandLess /> : <ExpandMore />}>
+                                {expanded ? 'Read Less' : 'Read More'}
+                            </Button>
+                        )}
                     </div>
                 </div>
-                {isOverflowing && (
-                    <Button
-                        style={{marginTop: 16}}
-                        onClick={togglePreviewHeight}
-                        variant="contained"
-                        color="primary"
-                        size="large"
-                        fullWidth={true}
-                        startIcon={expanded ? <ExpandLess /> : <ExpandMore />}>
-                        {expanded ? 'Read Less' : 'Read More'}
-                    </Button>
-                )}
             </Container>
         </div>
     );

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -40,6 +40,7 @@ const Messages = observer(() => {
             onExpand={(expanded) => (expandedState.current[message.id] = expanded)}
             title={message.title}
             date={message.date}
+            appName={appStore.getName(message.appid)}
             expanded={expandedState.current[message.id] ?? false}
             content={message.message}
             image={message.image}

--- a/ui/src/typedef/react-timeago.d.ts
+++ b/ui/src/typedef/react-timeago.d.ts
@@ -1,9 +1,19 @@
 declare module 'react-timeago' {
     import React from 'react';
 
+    export type FormatterOptions = {
+        style?: 'long' | 'short' | 'narrow';
+    };
+    export type Formatter = (options: FormatterOptions) => React.ReactNode;
+
     export interface ITimeAgoProps {
         date: string;
+        formatter?: Formatter;
     }
 
     export default class TimeAgo extends React.Component<ITimeAgoProps, unknown> {}
+}
+
+declare module 'react-timeago/defaultFormatter' {
+    declare function makeIntlFormatter(options: FormatterOptions): Formatter;
 }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 
-const GOTIFY_PORT = process.env.GOTIFY_PORT ?? '80';
+const GOTIFY_SERVER_PORT = process.env.GOTIFY_SERVER_PORT ?? '80';
 
 export default defineConfig({
     build: {
@@ -21,12 +21,12 @@ export default defineConfig({
         host: '0.0.0.0',
         proxy: {
             '^/(application|message|client|current|user|plugin|version|image)': {
-                target: `http://localhost:${GOTIFY_PORT}/`,
+                target: `http://localhost:${GOTIFY_SERVER_PORT}/`,
                 changeOrigin: true,
                 secure: false,
             },
             '/stream': {
-                target: `ws://localhost:${GOTIFY_PORT}/`,
+                target: `ws://localhost:${GOTIFY_SERVER_PORT}/`,
                 ws: true,
                 rewriteWsOrigin: true,
             },


### PR DESCRIPTION
Not sure if it shows up like this on your end as well. Tried fixing it, can't find a way to make App Logos show up on really small screens neatly so I think we should just hide it: it saves metered traffic as well.

Before:

<img width="1810" height="1254" alt="image" src="https://github.com/user-attachments/assets/4351b9fe-f382-4d75-9c01-506c69c231ec" />

<img width="960" height="2142" alt="image" src="https://github.com/user-attachments/assets/da6959ff-6810-48a3-9e83-0e4293aef9eb" />

After:

<img width="1806" height="1417" alt="image" src="https://github.com/user-attachments/assets/7874167a-e4c6-45ad-8d61-770046f9ad47" />
<img width="960" height="2142" alt="image" src="https://github.com/user-attachments/assets/f50c792d-917c-4b80-af18-152ea3cf2432" />
