### PR TITLE
switch to mobx-react-lite

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
     "axios": "^1.11.0",
     "detect-browser": "^5.3.0",
     "mobx": "^6.13.7",
-    "mobx-react": "^9.2.0",
+    "mobx-react-lite": "^4.1.0",
     "mobx-utils": "^6.1.1",
     "notifyjs": "^3.0.0",
     "notistack": "^3.0.2",

--- a/ui/src/client/Clients.tsx
+++ b/ui/src/client/Clients.tsx
@@ -17,7 +17,7 @@ import UpdateClientDialog from './UpdateClientDialog';
 import {IClient} from '../types';
 import CopyableSecret from '../common/CopyableSecret';
 import {LastUsedCell} from '../common/LastUsedCell';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {useStores} from '../stores';
 
 const Clients = observer(() => {

--- a/ui/src/common/SettingsDialog.tsx
+++ b/ui/src/common/SettingsDialog.tsx
@@ -6,7 +6,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {useStores} from '../stores';
 
 interface IProps {

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -14,7 +14,7 @@ import Plugins from '../plugin/Plugins';
 import Login from '../user/Login';
 import Messages from '../message/Messages';
 import Users from '../user/Users';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {ConnectionErrorBanner} from '../common/ConnectionErrorBanner';
 import {useStores} from '../stores';
 import {SnackbarProvider} from 'notistack';

--- a/ui/src/layout/Navigation.tsx
+++ b/ui/src/layout/Navigation.tsx
@@ -3,7 +3,7 @@ import Drawer from '@mui/material/Drawer';
 import {Theme} from '@mui/material/styles';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {mayAllowPermission, requestPermission} from '../snack/browserNotification';
 import {
     Button,

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -5,7 +5,7 @@ import {useParams} from 'react-router';
 import DefaultPage from '../common/DefaultPage';
 import Button from '@mui/material/Button';
 import Message from './Message';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {IMessage} from '../types';
 import ConfirmDialog from '../common/ConfirmDialog';
 import LoadingSpinner from '../common/LoadingSpinner';

--- a/ui/src/plugin/Plugins.tsx
+++ b/ui/src/plugin/Plugins.tsx
@@ -11,7 +11,7 @@ import Settings from '@mui/icons-material/Settings';
 import {Switch, Button} from '@mui/material';
 import DefaultPage from '../common/DefaultPage';
 import CopyableSecret from '../common/CopyableSecret';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {IPlugin} from '../types';
 import {useStores} from '../stores';
 

--- a/ui/src/user/Login.tsx
+++ b/ui/src/user/Login.tsx
@@ -7,7 +7,7 @@ import DefaultPage from '../common/DefaultPage';
 import * as config from '../config';
 import RegistrationDialog from './Register';
 import {useStores} from '../stores';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 import {useNavigate} from 'react-router';
 
 const Login = observer(() => {

--- a/ui/src/user/Users.tsx
+++ b/ui/src/user/Users.tsx
@@ -15,7 +15,7 @@ import Button from '@mui/material/Button';
 import AddEditDialog from './AddEditUserDialog';
 import {IUser} from '../types';
 import {useStores} from '../stores';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 
 interface IRowProps {
     name: string;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3106,13 +3106,6 @@ mobx-react-lite@^4.1.0:
   dependencies:
     use-sync-external-store "^1.4.0"
 
-mobx-react@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-9.2.0.tgz#c1e4d1ed406f6664d9de0787c948bac3a7ed5893"
-  integrity sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==
-  dependencies:
-    mobx-react-lite "^4.1.0"
-
 mobx-utils@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-6.1.1.tgz#61c66563e7646fb75462c189f4110a76d2e35768"


### PR DESCRIPTION
Since we switched to functional components we can use the lite version. 

We are already using it in a transitive way which only works on older package managers and can potentially link differently and it needs to be reconciled.

https://github.com/gotify/server/blob/43574a075cd5315f6eae2e146f6d951dbfa12ffa/ui/src/application/Applications.tsx#L24