### PR TITLE
change yarn telemetry to opt-in

### DIFF
--- a/ui/.yarnrc
+++ b/ui/.yarnrc
@@ -1,0 +1,1 @@
+enableTelemetry "0"


### PR DESCRIPTION
Since we upgraded UI I think we should disable the telemetries newer yarn versions have by default. This sets a default disable for package manager repositories for all builders, users can still opt-in with `--enableTelemetry`.


The legal reasoning is since we hide `yarn` behind `make` I don't really think telling the user to run `make build-js` counts as providing giving users an opportunity to consent.  

The technical reasoning is they claim the reason as:

> "Various threads in the Node docker image repositories suggested to remove Yarn from the Docker image ... because of the lack of telemetry, some projects also had trouble taking us seriously." [documentation](https://yarnpkg.com/advanced/telemetry)

Where? I gave it [a quick check](https://github.com/nodejs/docker-node/issues) and I do not see such debates (at least the problem is not simply "I don't think it is popular enough"). Most are functional, cost, SBOM and security concerns. I don't really believe the appropriate way to be "taken seriously" out of these issues is numerically monetizing your users for your project continuity without an explicit consent.

I also don't see similar telemetry systems being coded into the NPM or PNPM command line. Go also has [telemetry](https://go.dev/doc/telemetry) but they are opt-in and thus we are not making a choice on behalf of users. Yarn's opt-out approach feels particularly aggressive to me. 


Their RFC: https://github.com/yarnpkg/berry/issues/1250