### PR TITLE
fix: fix markdown embed image issue

### DIFF
--- a/ui/src/common/Markdown.tsx
+++ b/ui/src/common/Markdown.tsx
@@ -6,7 +6,11 @@ import gfm from 'remark-gfm';
 // Copy from mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
 // Related PR: https://github.com/mlflow/mlflow/pull/16761
 const urlTransform: UrlTransform = (value) => {
-    if (value.startsWith('data:image/png;') || value.startsWith('data:image/jpeg;') || value.startsWith('data:image/gif;')) {
+    if (
+        value.startsWith('data:image/png;') ||
+        value.startsWith('data:image/jpeg;') ||
+        value.startsWith('data:image/gif;')
+    ) {
         return value;
     }
     return defaultUrlTransform(value);


### PR DESCRIPTION
The new version of **react-markdown** cannot display images in the **embed** format. This issue can be fixed by following the method provided in the corresponding repository. Related issue: [https://github.com/remarkjs/react-markdown/issues/774#issuecomment-1743115270](https://github.com/remarkjs/react-markdown/issues/774#issuecomment-1743115270).
