### PR TITLE
fix: hide delete overlay for default app images

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -431,6 +431,7 @@ func (a *ApplicationAPI) RemoveApplicationImage(ctx *gin.Context) {
 
 func withResolvedImage(app *model.Application) *model.Application {
 	if app.Image == "" {
+		// This must stay in sync with the isDefaultImage check in ui/src/application/Applications.tsx.
 		app.Image = "static/defaultapp.png"
 	} else {
 		app.Image = "image/" + app.Image

--- a/ui/src/application/Applications.tsx
+++ b/ui/src/application/Applications.tsx
@@ -197,12 +197,16 @@ const Row = ({
     fEdit,
 }: IRowProps) => {
     const {classes} = useStyles();
+    const isDefaultImage = image === 'static/defaultapp.png';
     return (
         <TableRow>
             <TableCell padding="normal">
                 <div style={{display: 'flex'}}>
                     <Tooltip title="Delete image" placement="top" arrow>
-                        <ButtonBase className={classes.imageContainer} onClick={fDeleteImage}>
+                        <ButtonBase
+                            className={classes.imageContainer}
+                            onClick={fDeleteImage}
+                            disabled={isDefaultImage}>
                             <img
                                 src={config.get('url') + image}
                                 alt="app logo"


### PR DESCRIPTION
Whilst looking at #872 I found the ability to delete default app images to be confusing.

This PR simply adds a check if the image starts with `image/` which is different from the default which is `static/`. if false do not render the tooltip and the button which ultimately if rendered / used results in an error if clicked / go through the 2 step process.

before:
[Screencast_20251106_091748.webm](https://github.com/user-attachments/assets/79d5ac04-29b5-4f0d-8821-b55f3b216bf4)

after:
[Screencast_20251106_091930.webm](https://github.com/user-attachments/assets/79dda9b8-c316-43b0-af1b-3f56493ba7a1)
