### PR TITLE
Subpath handling for Gotify (#533)

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -27,6 +27,7 @@ import (
 func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Configuration) (*gin.Engine, func()) {
 	g := gin.New()
 
+	g.RemoveExtraSlash = true
 	g.RemoteIPHeaders = []string{"X-Forwarded-For"}
 	g.SetTrustedProxies(conf.Server.TrustedProxies)
 	g.ForwardedByClientIP = true


### PR DESCRIPTION
This PR fixes an issue where Gotify does not normalize URLs, which can lead to double slashes (e.g., `http://localhost//message`) causing 404 errors.

Before:
<img width="1237" height="75" alt="Screenshot 2025-11-18 at 1 38 38 PM" src="https://github.com/user-attachments/assets/703e45c5-8795-4100-9984-7d9e99401e95" />
After:
<img width="1266" height="76" alt="Screenshot 2025-11-18 at 1 39 44 PM" src="https://github.com/user-attachments/assets/e6280310-fbb0-4005-9b8a-fb986628a4ff" />

Test Proxies 
**Apache**
```
<VirtualHost *:8080>
    ServerName localhost
    Keepalive On
    ProxyPreserveHost On

    # WebSocket
    ProxyPass "/stream" ws://127.0.0.1:80/stream retry=0 timeout=60

    # HTTP
    ProxyPass "/" http://127.0.0.1:80/ retry=0 timeout=5
    ProxyPassReverse "/" http://127.0.0.1:80/
</VirtualHost>
```
Result:
<img width="1238" height="59" alt="Screenshot 2025-11-18 at 1 35 50 PM" src="https://github.com/user-attachments/assets/22b09022-489d-490b-8fca-a1a017868632" />

**Apache subpath**
```
<VirtualHost *:8080>
    ServerName localhost
    Keepalive On

    # Redirect /gotify to /gotify/ (trailing slash)
    Redirect 301 "/gotify" "/gotify/"

    # Preserve host for Gotify WebSocket verification
    ProxyPreserveHost On

    # Proxy WebSocket requests under /gotify/stream
    ProxyPass "/gotify/stream" ws://127.0.0.1:80/stream retry=0 timeout=60

    # Proxy all other /gotify/ requests to Gotify server
    ProxyPass "/gotify/" http://127.0.0.1:80/ retry=0 timeout=5
    ProxyPassReverse "/gotify/" http://127.0.0.1:80/
</VirtualHost>
```
Result:
<img width="1240" height="99" alt="Screenshot 2025-11-18 at 1 35 00 PM" src="https://github.com/user-attachments/assets/706f8654-d621-4b33-bdab-bce5368b0b18" />

**Caddy**
```
http://localhost:8080 {
    reverse_proxy localhost:80
}
```
Result:
<img width="1239" height="83" alt="Screenshot 2025-11-18 at 1 28 23 PM" src="https://github.com/user-attachments/assets/23b74d5f-a20d-4e63-8dd2-9d9b7f2f02a2" />


**Caddy subpath**
```
http://localhost:8080 {
  route /gotify/* {
    uri strip_prefix /gotify
    reverse_proxy localhost:80
  }
  redir /gotify /gotify/
}
```
Result:
<img width="1239" height="72" alt="Screenshot 2025-11-18 at 1 32 30 PM" src="https://github.com/user-attachments/assets/ca82586d-d90e-40e4-afca-d5a6962eecf6" />

**Haproxy**
```
frontend www
    bind 0.0.0.0:8080
    default_backend backend_gotify
    timeout client 60s
    timeout client-fin 30s

backend backend_gotify
    server backend01 127.0.0.1:80 check
    timeout connect 10s
    timeout server 60s
```
Result:
<img width="1331" height="81" alt="Screenshot 2025-11-18 at 1 22 55 PM" src="https://github.com/user-attachments/assets/ef83126d-c4a5-476b-9c6d-27baf6568cd2" />

**NGINX**
```
http {
    include       mime.types;
    default_type  application/octet-stream;
    sendfile        on;
    keepalive_timeout  65;

    upstream gotify {
        server 127.0.0.1:80;  # Gotify server port
    }

    server {
        listen 8080;  # Proxy port
        location / {
            proxy_pass http://gotify;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "upgrade";
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto http;
            proxy_redirect http:// $scheme://;
            proxy_set_header Host $http_host;

            proxy_connect_timeout 1m;
            proxy_send_timeout 1m;
            proxy_read_timeout 1m;
        }
    }
    include servers/*;
}
```
Result:
<img width="1251" height="61" alt="Screenshot 2025-11-18 at 1 10 28 PM" src="https://github.com/user-attachments/assets/ba75e7de-b3ce-4aab-9650-79a16cf2b560" />

**NGINX subpath**
```
http {
    include       mime.types;
    default_type  application/octet-stream;
    sendfile        on;
    keepalive_timeout  65;

upstream gotify {
    server 127.0.0.1:80;  # Gotify server running locally on 80
}

server {
    listen 8080;
    location /gotify/ {
        # Strip the /gotify prefix
        rewrite ^/gotify(/.*)$ $1 break;

        proxy_pass         http://gotify;
        proxy_http_version 1.1;

        # WebSocket support
        proxy_set_header   Upgrade $http_upgrade;
        proxy_set_header   Connection "upgrade";

        # Forward client info
        proxy_set_header   X-Real-IP $remote_addr;
        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header   X-Forwarded-Proto http;

        # Preserve host for Gotify verification
        proxy_set_header   Host $http_host;

        proxy_connect_timeout   1m;
        proxy_send_timeout      1m;
        proxy_read_timeout      1m;
    }
}
    include servers/*;
}
```
<img width="1347" height="78" alt="Screenshot 2025-11-18 at 1 17 13 PM" src="https://github.com/user-attachments/assets/ca5eb9c8-011d-4228-a9df-470e95999e89" />

**Traefik**
```
# traefik.yml
entryPoints:
  web:
    address: ":8080"

providers:
  file:
    directory: "./conf.d"

# ./conf.d/gotify.yml
http:
  routers:
    gotify:
      rule: "Host(`localhost`)"
      entryPoints:
        - web
      service: gotify-service

  services:
    gotify-service:
      loadBalancer:
        servers:
          - url: "http://127.0.0.1:80"
```
Result:
<img width="883" height="74" alt="Screenshot 2025-11-18 at 1 06 21 PM" src="https://github.com/user-attachments/assets/dac6841a-3e63-4c7e-af20-d1b580534902" />
