### PR TITLE
fix: always use English for TimeAgo

### DIFF
--- a/ui/src/common/LastUsedCell.tsx
+++ b/ui/src/common/LastUsedCell.tsx
@@ -1,7 +1,7 @@
 import {Typography} from '@mui/material';
 import React from 'react';
 import TimeAgo from 'react-timeago';
-import {TimeAgoFormatter} from './TimeAgoConfig';
+import {TimeAgoFormatter} from './TimeAgoFormatter';
 
 export const LastUsedCell: React.FC<{lastUsed: string | null}> = ({lastUsed}) => {
     if (lastUsed === null) {
@@ -12,5 +12,5 @@ export const LastUsedCell: React.FC<{lastUsed: string | null}> = ({lastUsed}) =>
         return <Typography title={lastUsed}>Recently</Typography>;
     }
 
-    return <TimeAgo date={lastUsed} formatter={TimeAgoFormatter.get('long')} />;
+    return <TimeAgo date={lastUsed} formatter={TimeAgoFormatter.long} />;
 };

--- a/ui/src/common/TimeAgoConfig.ts
+++ b/ui/src/common/TimeAgoConfig.ts
@@ -1,7 +1,0 @@
-import {Formatter} from 'react-timeago';
-import {makeIntlFormatter} from 'react-timeago/defaultFormatter';
-
-export const TimeAgoFormatter: Map<'long' | 'narrow', Formatter> = new Map([
-    ['long', makeIntlFormatter({style: 'long', locale: 'en'})],
-    ['narrow', makeIntlFormatter({style: 'narrow', locale: 'en'})],
-]);

--- a/ui/src/common/TimeAgoFormatter.ts
+++ b/ui/src/common/TimeAgoFormatter.ts
@@ -1,0 +1,7 @@
+import {Formatter} from 'react-timeago';
+import {makeIntlFormatter} from 'react-timeago/defaultFormatter';
+
+export const TimeAgoFormatter: Record<'long' | 'narrow', Formatter> = {
+    long: makeIntlFormatter({style: 'long', locale: 'en'}),
+    narrow: makeIntlFormatter({style: 'narrow', locale: 'en'}),
+};

--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -11,7 +11,7 @@ import {Markdown} from '../common/Markdown';
 import * as config from '../config';
 import {IMessageExtras} from '../types';
 import {contentType, RenderMode} from './extras';
-import {TimeAgoFormatter} from '../common/TimeAgoConfig';
+import {TimeAgoFormatter} from '../common/TimeAgoFormatter';
 
 const PREVIEW_LENGTH = 500;
 
@@ -248,7 +248,7 @@ const HeaderWide = ({
                 </Typography>
             </div>
             <Typography variant="body1" className={classes.date}>
-                <TimeAgo date={date} formatter={TimeAgoFormatter.get('narrow')} />
+                <TimeAgo date={date} formatter={TimeAgoFormatter.narrow} />
             </Typography>
             <IconButton
                 onClick={fDelete}
@@ -279,7 +279,7 @@ const HeaderSmall = ({
                     {appName}
                 </Typography>
                 <Typography variant="body1" className={classes.date}>
-                    <TimeAgo date={date} formatter={TimeAgoFormatter.get('long')} />
+                    <TimeAgo date={date} formatter={TimeAgoFormatter.long} />
                 </Typography>
             </div>
             <div style={{display: 'flex', alignItems: 'end', flexDirection: 'column'}}>

--- a/ui/src/typedef/react-timeago.d.ts
+++ b/ui/src/typedef/react-timeago.d.ts
@@ -3,7 +3,7 @@ declare module 'react-timeago' {
 
     export type FormatterOptions = {
         style?: 'long' | 'short' | 'narrow';
-        locale?: void | string;
+        locale?: string;
     };
     export type Formatter = (options: FormatterOptions) => React.ReactNode;
 


### PR DESCRIPTION
Fixes #893 

Also lifted the config out to a global object per the docs for performance.