### PR TITLE
fix: MobX V6 actions

### DIFF
--- a/ui/src/CurrentUser.ts
+++ b/ui/src/CurrentUser.ts
@@ -2,7 +2,7 @@ import axios, {AxiosError, AxiosResponse} from 'axios';
 import * as config from './config';
 import {detect} from 'detect-browser';
 import {SnackReporter} from './snack/SnackManager';
-import {observable, makeObservable, runInAction, action} from 'mobx';
+import {observable, runInAction, action} from 'mobx';
 import {IClient, IUser} from './types';
 
 const tokenKey = 'gotify-login-key';
@@ -11,21 +11,13 @@ export class CurrentUser {
     private tokenCache: string | null = null;
     private reconnectTimeoutId: number | null = null;
     private reconnectTime = 7500;
-    public loggedIn = false;
-    public refreshKey = 0;
-    public authenticating = true;
-    public user: IUser = {name: 'unknown', admin: false, id: -1};
-    public connectionErrorMessage: string | null = null;
+    @observable accessor loggedIn = false;
+    @observable accessor refreshKey = 0;
+    @observable accessor authenticating = true;
+    @observable accessor user: IUser = {name: 'unknown', admin: false, id: -1};
+    @observable accessor connectionErrorMessage: string | null = null;
 
-    public constructor(private readonly snack: SnackReporter) {
-        makeObservable(this, {
-            loggedIn: observable,
-            authenticating: observable,
-            user: observable,
-            connectionErrorMessage: observable,
-            refreshKey: observable,
-        });
-    }
+    public constructor(private readonly snack: SnackReporter) {}
 
     public token = (): string => {
         if (this.tokenCache !== null) {

--- a/ui/src/application/AppStore.ts
+++ b/ui/src/application/AppStore.ts
@@ -1,7 +1,7 @@
 import {BaseStore} from '../common/BaseStore';
 import axios from 'axios';
 import * as config from '../config';
-import {action, makeObservable} from 'mobx';
+import {action} from 'mobx';
 import {SnackReporter} from '../snack/SnackManager';
 import {IApplication} from '../types';
 
@@ -10,12 +10,6 @@ export class AppStore extends BaseStore<IApplication> {
 
     public constructor(private readonly snack: SnackReporter) {
         super();
-
-        makeObservable(this, {
-            uploadImage: action,
-            update: action,
-            create: action,
-        });
     }
 
     protected requestItems = (): Promise<IApplication[]> =>
@@ -29,6 +23,7 @@ export class AppStore extends BaseStore<IApplication> {
             return this.snack('Application deleted');
         });
 
+    @action
     public uploadImage = async (id: number, file: Blob): Promise<void> => {
         const formData = new FormData();
         formData.append('file', file);
@@ -50,6 +45,7 @@ export class AppStore extends BaseStore<IApplication> {
         }
     }
 
+    @action
     public update = async (
         id: number,
         name: string,
@@ -65,6 +61,7 @@ export class AppStore extends BaseStore<IApplication> {
         this.snack('Application updated');
     };
 
+    @action
     public create = async (
         name: string,
         description: string,

--- a/ui/src/client/ClientStore.ts
+++ b/ui/src/client/ClientStore.ts
@@ -1,19 +1,13 @@
 import {BaseStore} from '../common/BaseStore';
 import axios from 'axios';
 import * as config from '../config';
-import {action, makeObservable} from 'mobx';
+import {action} from 'mobx';
 import {SnackReporter} from '../snack/SnackManager';
 import {IClient} from '../types';
 
 export class ClientStore extends BaseStore<IClient> {
     public constructor(private readonly snack: SnackReporter) {
         super();
-
-        makeObservable(this, {
-            update: action,
-            createNoNotifcation: action,
-            create: action,
-        });
     }
 
     protected requestItems = (): Promise<IClient[]> =>
@@ -25,18 +19,21 @@ export class ClientStore extends BaseStore<IClient> {
             .then(() => this.snack('Client deleted'));
     }
 
+    @action
     public update = async (id: number, name: string): Promise<void> => {
         await axios.put(`${config.get('url')}client/${id}`, {name});
         await this.refresh();
         this.snack('Client updated');
     };
 
+    @action
     public createNoNotifcation = async (name: string): Promise<IClient> => {
         const client = await axios.post(`${config.get('url')}client`, {name});
         await this.refresh();
         return client.data;
     };
 
+    @action
     public create = async (name: string): Promise<void> => {
         await this.createNoNotifcation(name);
         this.snack('Client added');

--- a/ui/src/common/BaseStore.ts
+++ b/ui/src/common/BaseStore.ts
@@ -1,4 +1,4 @@
-import {action, observable, makeObservable} from 'mobx';
+import {action, observable} from 'mobx';
 
 interface HasID {
     id: number;
@@ -12,17 +12,19 @@ export interface IClearable {
  * Base implementation for handling items with ids.
  */
 export abstract class BaseStore<T extends HasID> implements IClearable {
-    protected items: T[] = [];
+    @observable protected accessor items: T[] = [];
 
     protected abstract requestItems(): Promise<T[]>;
 
     protected abstract requestDelete(id: number): Promise<void>;
 
+    @action
     public remove = async (id: number): Promise<void> => {
         await this.requestDelete(id);
         await this.refresh();
     };
 
+    @action
     public refresh = (): Promise<void> =>
         this.requestItems().then(
             action((items) => {
@@ -30,6 +32,7 @@ export abstract class BaseStore<T extends HasID> implements IClearable {
             })
         );
 
+    @action
     public refreshIfMissing = async (id: number): Promise<void> => {
         if (this.getByIDOrUndefined(id) === undefined) {
             await this.refresh();
@@ -49,18 +52,8 @@ export abstract class BaseStore<T extends HasID> implements IClearable {
 
     public getItems = (): T[] => this.items;
 
+    @action
     public clear = (): void => {
         this.items = [];
     };
-
-    constructor() {
-        // eslint-disable-next-line
-        makeObservable<BaseStore<any>, 'items'>(this, {
-            items: observable,
-            remove: action,
-            refresh: action,
-            refreshIfMissing: action,
-            clear: action,
-        });
-    }
 }

--- a/ui/src/message/MessagesStore.ts
+++ b/ui/src/message/MessagesStore.ts
@@ -1,5 +1,5 @@
 import {BaseStore} from '../common/BaseStore';
-import {action, IObservableArray, observable, reaction, makeObservable, runInAction} from 'mobx';
+import {action, IObservableArray, observable, reaction, runInAction} from 'mobx';
 import axios, {AxiosResponse} from 'axios';
 import * as config from '../config';
 import {createTransformer} from 'mobx-utils';
@@ -22,8 +22,8 @@ interface PendingDelete {
 }
 
 export class MessagesStore {
-    private state: Record<string, MessagesState> = {};
-    private pendingDeletes: Map<number, PendingDelete> = observable.map();
+    @observable private accessor state: Record<string, MessagesState> = {};
+    @observable private accessor pendingDeletes: Map<number, PendingDelete> = observable.map();
 
     private loading = false;
 
@@ -31,20 +31,6 @@ export class MessagesStore {
         private readonly appStore: BaseStore<IApplication>,
         private readonly snack: SnackReporter
     ) {
-        makeObservable<MessagesStore, 'state' | 'pendingDeletes'>(this, {
-            state: observable,
-            pendingDeletes: observable,
-            addPendingDelete: action,
-            executePendingDeletes: action,
-            cancelPendingDelete: action,
-            loadMore: action,
-            publishSingleMessage: action,
-            removeByApp: action,
-            removeSingle: action,
-            clearAll: action,
-            refreshByApp: action,
-        });
-
         reaction(() => appStore.getItems(), this.createEmptyStatesForApps);
     }
 
@@ -59,6 +45,7 @@ export class MessagesStore {
 
     public canLoadMore = (appId: number) => this.stateOf(appId, /*create*/ false).hasMore;
 
+    @action
     public loadMore = async (appId: number) => {
         const state = this.stateOf(appId);
         if (!state.hasMore || this.loading) {
@@ -83,6 +70,7 @@ export class MessagesStore {
         return Promise.resolve();
     };
 
+    @action
     public publishSingleMessage = (message: IMessage) => {
         if (this.exists(AllMessages)) {
             this.stateOf(AllMessages).messages.unshift(message);
@@ -92,6 +80,7 @@ export class MessagesStore {
         }
     };
 
+    @action
     public removeByApp = async (appId: number) => {
         if (appId === AllMessages) {
             await axios.delete(config.get('url') + 'message');
@@ -106,9 +95,11 @@ export class MessagesStore {
         await this.loadMore(appId);
     };
 
+    @action
     public addPendingDelete = (pending: PendingDelete) =>
         this.pendingDeletes.set(pending.message.id, pending);
 
+    @action
     public cancelPendingDelete = (message: IMessage): boolean => {
         const pending = this.pendingDeletes.get(message.id);
         if (pending) {
@@ -118,11 +109,13 @@ export class MessagesStore {
         return !!pending;
     };
 
+    @action
     public executePendingDeletes = () =>
         Array.from(this.pendingDeletes.values()).forEach(({message}) => this.removeSingle(message));
 
     public visible = (message: number): boolean => !this.pendingDeletes.has(message);
 
+    @action
     public removeSingle = async (message: IMessage) => {
         if (!this.pendingDeletes.has(message.id)) {
             return;
@@ -160,11 +153,13 @@ export class MessagesStore {
         this.snack(`Message sent to ${app.name}`);
     };
 
+    @action
     public clearAll = () => {
         this.state = {};
         this.createEmptyStatesForApps(this.appStore.getItems());
     };
 
+    @action
     public refreshByApp = async (appId: number) => {
         this.clearAll();
         this.loadMore(appId);

--- a/ui/src/plugin/PluginStore.ts
+++ b/ui/src/plugin/PluginStore.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {action, makeObservable} from 'mobx';
+import {action} from 'mobx';
 import {BaseStore} from '../common/BaseStore';
 import * as config from '../config';
 import {SnackReporter} from '../snack/SnackManager';
@@ -10,11 +10,6 @@ export class PluginStore extends BaseStore<IPlugin> {
 
     public constructor(private readonly snack: SnackReporter) {
         super();
-
-        makeObservable(this, {
-            changeConfig: action,
-            changeEnabledState: action,
-        });
     }
 
     public requestConfig = (id: number): Promise<string> =>
@@ -36,6 +31,7 @@ export class PluginStore extends BaseStore<IPlugin> {
         return id === -1 ? 'All Plugins' : plugin !== undefined ? plugin.name : 'unknown';
     };
 
+    @action
     public changeConfig = async (id: number, newConfig: string): Promise<void> => {
         await axios.post(`${config.get('url')}plugin/${id}/config`, newConfig, {
             headers: {'content-type': 'application/x-yaml'},
@@ -44,6 +40,7 @@ export class PluginStore extends BaseStore<IPlugin> {
         await this.refresh();
     };
 
+    @action
     public changeEnabledState = async (id: number, enabled: boolean): Promise<void> => {
         await axios.post(`${config.get('url')}plugin/${id}/${enabled ? 'enable' : 'disable'}`);
         this.snack(`Plugin ${enabled ? 'enabled' : 'disabled'}`);

--- a/ui/src/user/UserStore.ts
+++ b/ui/src/user/UserStore.ts
@@ -1,18 +1,13 @@
 import {BaseStore} from '../common/BaseStore';
 import axios from 'axios';
 import * as config from '../config';
-import {action, makeObservable} from 'mobx';
+import {action} from 'mobx';
 import {SnackReporter} from '../snack/SnackManager';
 import {IUser} from '../types';
 
 export class UserStore extends BaseStore<IUser> {
     constructor(private readonly snack: SnackReporter) {
         super();
-
-        makeObservable(this, {
-            create: action,
-            update: action,
-        });
     }
 
     protected requestItems = (): Promise<IUser[]> =>
@@ -24,12 +19,14 @@ export class UserStore extends BaseStore<IUser> {
             .then(() => this.snack('User deleted'));
     }
 
+    @action
     public create = async (name: string, pass: string, admin: boolean) => {
         await axios.post(`${config.get('url')}user`, {name, pass, admin});
         await this.refresh();
         this.snack('User created');
     };
 
+    @action
     public update = async (id: number, name: string, pass: string | null, admin: boolean) => {
         await axios.post(config.get('url') + 'user/' + id, {name, pass, admin});
         await this.refresh();


### PR DESCRIPTION
Gets rid of warnings like:

```
[MobX] Since strict-mode is enabled, changing (observed) observable values without using an action is not allowed. Tried to modify: CurrentUser@6.loggedIn
```

I don't find any behavioral breakage but wrapping them in actions should be more conformant.

doc: https://mobx.js.org/actions.html#asynchronous-actions