### PR TITLE
enhance: bump token keyspace to >128 bits

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	tokenCharacters   = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_")
-	randomTokenLength = 14
+	randomTokenLength = 22 // ~2^132.5 keyspace (7.65e+39)
 	applicationPrefix = "A"
 	clientPrefix      = "C"
 	pluginPrefix      = "P"


### PR DESCRIPTION
Previous keyspace: 2^84.3131 (2.40e25) , we are moving to 2^132.5 keyspace (7.65e+39)

Closes #936 

The original length is indeed on the legacy end of the spectrum and slightly behind OWASP recommendations for a password without MFA , therefore I think it's good to bump it to >128 bits to push it well into cryptographic secret strength that TLS/SSH accepts and collision resistance on SHA256 is targeted at. Maybe this can also simplify some workflows if some users want's to built ad hoc E2EE systems. 

Regardng the proposal in #936 I don't see the need to add a token length option because the "ceiling" of security (TLS) is clear and achievable by simply bumping the constant. Creating a knob can lead to downstream problems like tokens too long causing them to not fit in certain webhook forms, etc. 

The increase in character count is modest, so I don't expect any issues with URL or webhook form length not fitting, but after the increase we can confidently say at least regarding the brute force attack vector TLS would be the weakest link by every metric.