### PR TITLE
fix(ui): make messages layout responsive

### DIFF
--- a/ui/src/message/Message.tsx
+++ b/ui/src/message/Message.tsx
@@ -80,6 +80,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
         },
         '& pre': {
             overflow: 'auto',
+            maxWidth: '100%',
             borderRadius: '0.25em',
             backgroundColor:
                 theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)',
@@ -168,6 +169,10 @@ const Message = ({
                 style={{
                     display: 'flex',
                     flexWrap: 'wrap',
+                    width: 'fit-content',
+                    minWidth: 'min(700px, 100%)',
+                    maxWidth: '100%',
+                    margin: '0 auto',
                     borderLeftColor: priorityColor(priority),
                     borderLeftWidth: 6,
                     borderLeftStyle: 'solid',

--- a/ui/src/message/Messages.tsx
+++ b/ui/src/message/Messages.tsx
@@ -115,6 +115,7 @@ const Messages = observer(() => {
     return (
         <DefaultPage
             title={name}
+            maxWidth={1600}
             rightControl={
                 <div>
                     {app && (


### PR DESCRIPTION
## ✨ Summary

This improves the responsiveness of the WebUI Messages page.

The Messages page was previously constrained by the default `DefaultPage` width, which made the message list feel unnecessarily narrow on desktop screens and left a lot of available horizontal space unused.

This PR keeps the change scoped to the Messages page and preserves the existing layout for the other pages.

Fixes #744

## 🖥️ Desktop behavior

On larger desktop screens, the Messages page now uses more of the available horizontal space while still keeping a reasonable maximum width.

This makes long notifications, logs, Markdown content, and code blocks much easier to read without changing the overall Gotify layout.

## 🔧 Changes

- Set a wider `maxWidth` only for the Messages page.
- Size individual message cards based on their content.
- Keep short text-only messages compact.
- Allow messages with wide content, such as logs or code blocks, to expand up to the available page width.
- Clamp `<pre>` blocks to the message card width while preserving internal horizontal scrolling.
- Leave the other pages unchanged.

### ✅ Tested

I tested the change locally on:

- 🖥️ Desktop
- 💻 Laptop
- 📱 Mobile web viewport

Everything works as expected:
- the Messages page uses much more available width on desktop;
- the layout remains clean on laptop/tablet-sized screens;
- mobile web keeps message cards within the viewport while preserving code block horizontal scrolling;
- the Android app is not affected;
- existing messages, apps, clients, and WebSocket updates continue to work.

## 📸 Screenshots
### Desktop :
<img width="3830" height="1868" alt="image" src="https://github.com/user-attachments/assets/a52d44c7-4022-430b-9039-31168c521953" />

### Laptop :

<img width="2688" height="1396" alt="laptop" src="https://github.com/user-attachments/assets/77b93c9e-fdc5-4ae2-9efe-a3fbde71c8db" />

### Mobile web :

<img width="314" height="619" alt="image" src="https://github.com/user-attachments/assets/dad72a4b-b2f7-4de6-97a3-9f14644468d6" />
