### PR TITLE
feat: add configurable instance title (closes #949)

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -2,6 +2,7 @@
 # Save it to `config.yml` when edited
 
 server:
+  title: Gotify # the instance title
   keepaliveperiodseconds: 0 # 0 = use Go default (15s); -1 = disable keepalive; set the interval in which keepalive packets will be sent. Only change this value if you know what you are doing.
   listenaddr: '' # the address to bind on, leave empty to bind on all addresses. Prefix with "unix:" to create a unix socket. Example: "unix:/tmp/gotify.sock".
   port: 80 # the port the HTTP server will listen on

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Configuration struct {
 		KeepAlivePeriodSeconds int
 		ListenAddr             string `default:""`
 		Port                   int    `default:"80"`
+		Title                  string `default:"Gotify"`
 
 		SSL struct {
 			Enabled         bool   `default:"false"`

--- a/model/gotifyinfo.go
+++ b/model/gotifyinfo.go
@@ -19,4 +19,9 @@ type GotifyInfo struct {
 	// required: true
 	// example: true
 	Oidc bool `json:"oidc"`
+	// The instance title.
+	//
+	// required: true
+	// example: Gotify
+	Title string `json:"title"`
 }

--- a/router/router.go
+++ b/router/router.go
@@ -114,7 +114,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	userChangeNotifier.OnUserDeleted(pluginManager.RemoveUser)
 	userChangeNotifier.OnUserAdded(pluginManager.InitializeForUserID)
 
-	ui.Register(g, *vInfo, conf.Registration, conf.OIDC.Enabled)
+	ui.Register(g, *vInfo, conf.Registration, conf.OIDC.Enabled, conf.Server.Title)
 
 	if conf.OIDC.Enabled {
 		oidcHandler := api.NewOIDC(conf, db, userChangeNotifier)
@@ -185,7 +185,7 @@ func Create(db *database.GormDatabase, vInfo *model.VersionInfo, conf *config.Co
 	//     schema:
 	//         $ref: "#/definitions/GotifyInfo"
 	g.GET("gotifyinfo", func(ctx *gin.Context) {
-		ctx.JSON(200, &model.GotifyInfo{Version: vInfo.Version, Oidc: conf.OIDC.Enabled, Register: conf.Registration})
+		ctx.JSON(200, &model.GotifyInfo{Version: vInfo.Version, Title: conf.Server.Title, Oidc: conf.OIDC.Enabled, Register: conf.Registration})
 	})
 
 	g.Group("/").Use(authentication.RequireApplicationToken).POST("/message", messageHandler.CreateMessage)

--- a/ui/serve.go
+++ b/ui/serve.go
@@ -19,11 +19,12 @@ type uiConfig struct {
 	Register bool              `json:"register"`
 	Version  model.VersionInfo `json:"version"`
 	OIDC     bool              `json:"oidc"`
+	Title    string            `json:"title"`
 }
 
 // Register registers the ui on the root path.
-func Register(r *gin.Engine, version model.VersionInfo, register, oidcEnabled bool) {
-	uiConfigBytes, err := json.Marshal(uiConfig{Version: version, Register: register, OIDC: oidcEnabled})
+func Register(r *gin.Engine, version model.VersionInfo, register, oidcEnabled bool, title string) {
+	uiConfigBytes, err := json.Marshal(uiConfig{Version: version, Register: register, OIDC: oidcEnabled, Title: title})
 	if err != nil {
 		panic(err)
 	}

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -5,6 +5,7 @@ export interface IConfig {
     register: boolean;
     version: IVersion;
     oidc: boolean;
+    title: string;
 }
 
 declare global {
@@ -18,6 +19,7 @@ const config: IConfig = {
     register: false,
     version: {commit: 'unknown', buildDate: 'unknown', version: 'unknown'},
     oidc: false,
+    title: 'Gotify',
     ...window.config,
 };
 

--- a/ui/src/layout/Header.tsx
+++ b/ui/src/layout/Header.tsx
@@ -17,6 +17,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import Apps from '@mui/icons-material/Apps';
 import SupervisorAccount from '@mui/icons-material/SupervisorAccount';
 import React, {CSSProperties} from 'react';
+import * as config from '../config';
 import {Link} from 'react-router-dom';
 import {useMediaQuery} from '@mui/material';
 import {ThemeKey} from './theme';
@@ -108,7 +109,7 @@ const Header = ({
                 <div className={classes.title}>
                     <Link to="/" className={classes.link}>
                         <Typography variant="h5" className={classes.titleName} color="inherit">
-                            Gotify
+                            {config.get('title')}
                         </Typography>
                     </Link>
                     <a

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -75,6 +75,7 @@ const Layout = observer(() => {
         [paletteMode]
     );
     const {version} = config.get('version');
+    React.useEffect(() => { document.title = config.get('title'); }, []);
     const [navOpen, setNavOpen] = React.useState(false);
     const [showSettings, setShowSettings] = React.useState(false);
 


### PR DESCRIPTION
Add a `server.title` config field to customize the instance name.

Changes:
- **Config:** `server.title` defaults to `"Gotify"`
- **API:** `/gotifyinfo` returns the title alongside existing fields
- **UI:** document title and header reflect the configured title
- **Docs:** documented in `config.example.yml`

The maintainer previously expressed support for this feature in the issue. Implementation is minimal (8 files, ~17 lines net).

Closes #949