### PR TITLE
ci(renovate): don't automatically rebase PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "labels": [
     "dependencies"
   ],
+  "rebaseWhen": "never",
   "reviewersFromCodeOwners": true,
   "enabledManagers": [
     "npm",


### PR DESCRIPTION
We normally keep the PRs open for some time, this disables the auto rebasing, to reduce the spam of notifications. We can use the checkbox to rebase when we want to merge the PRs.

Another possible way would be enabling auto merging, but I generally like to glance over the changelog that will be merged. What do you think @eternal-flame-AD?