### PR TITLE
Env config migrate

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gotify/server/v2/config"
+	"github.com/gotify/server/v2/config/migrate"
 	"github.com/gotify/server/v2/database"
 	"github.com/gotify/server/v2/mode"
 	"github.com/gotify/server/v2/model"
@@ -60,6 +61,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 		if ok {
 			fmt.Fprintln(stdout, b)
 		}
+		return 0
+	case "migrate-config":
+		content, err := migrate.Config(fs.Arg(1))
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintln(stdout, content)
 		return 0
 	default:
 		if command != "" {

--- a/app.go
+++ b/app.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/gotify/server/v2/config"
@@ -27,7 +32,45 @@ var (
 )
 
 func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
 	vInfo := &model.VersionInfo{Version: Version, Commit: Commit, BuildDate: BuildDate}
+	fs := flag.NewFlagSet("gotify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { printUsage(stderr) }
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	command := fs.Arg(0)
+	switch command {
+	case "serve", "":
+		return serve(vInfo)
+	case "version":
+		fmt.Fprintln(stdout, "Version:", vInfo.Version)
+		fmt.Fprintln(stdout, "Commit:", vInfo.Commit)
+		fmt.Fprintln(stdout, "Build Date:", vInfo.BuildDate)
+		fmt.Fprintln(stdout, "Go Build Info:")
+		b, ok := debug.ReadBuildInfo()
+		if ok {
+			fmt.Fprintln(stdout, b)
+		}
+		return 0
+	default:
+		if command != "" {
+			fmt.Fprintf(stderr, "gotify: unknown command %q\n\n", command)
+		}
+		printUsage(stderr)
+		return 2
+	}
+}
+
+func serve(vInfo *model.VersionInfo) int {
 	mode.Set(Mode)
 
 	conf, futureLogs := config.Get()
@@ -40,21 +83,24 @@ func main() {
 		exit = exit || futureLog.Level == zerolog.FatalLevel || futureLog.Level == zerolog.PanicLevel
 	}
 	if exit {
-		os.Exit(1)
+		return 1
 	}
 
 	if conf.PluginsDir != "" {
 		if err := os.MkdirAll(conf.PluginsDir, 0o755); err != nil {
-			panic(err)
+			log.Error().Err(err).Str("dir", conf.PluginsDir).Msg("Cannot create plugins directory")
+			return 1
 		}
 	}
 	if err := os.MkdirAll(conf.UploadedImagesDir, 0o755); err != nil {
-		panic(err)
+		log.Error().Err(err).Str("dir", conf.UploadedImagesDir).Msg("Cannot create uploaded images directory")
+		return 1
 	}
 
 	db, err := database.New(conf.Database.Dialect, conf.Database.Connection, conf.DefaultUser.Name, conf.DefaultUser.Pass, conf.PassStrength, true, time.Now)
 	if err != nil {
-		panic(err)
+		log.Error().Err(err).Msg("Cannot initialize database")
+		return 1
 	}
 	defer db.Close()
 
@@ -63,8 +109,20 @@ func main() {
 
 	if err := runner.Run(engine, conf); err != nil {
 		log.Error().Err(err).Msg("Server error")
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage: gotify [flags] <command> [arguments]
+
+Commands:
+  serve                       Start the Gotify server.
+  migrate-config <file.yml>   Convert an old YAML config file to the new env
+                              format and print it to stdout.
+  version                     Show version information
+`)
 }
 
 func noColor(noColorEnv string) bool {

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantCode int
+		stdout   string // substring expected on stdout
+		stderr   string // substring expected on stderr
+	}{
+		{"version", []string{"version"}, 0, "Version: ", ""},
+		{"unknown command", []string{"bogus"}, 2, "", "unknown command"},
+		{"unknown flag", []string{"--nope"}, 2, "", "not defined"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(c.args, &stdout, &stderr)
+			assert.Equal(t, c.wantCode, code)
+			assert.Contains(t, stdout.String(), c.stdout)
+			assert.Contains(t, stderr.String(), c.stderr)
+		})
+	}
+}

--- a/config/migrate/migrate.go
+++ b/config/migrate/migrate.go
@@ -1,0 +1,185 @@
+package migrate
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gotify/server/v2/config"
+	"github.com/joho/godotenv"
+	"gopkg.in/yaml.v3"
+)
+
+type oldConfig struct {
+	Server struct {
+		KeepAlivePeriodSeconds *int
+		ListenAddr             *string
+		Port                   *int
+		SSL                    struct {
+			Enabled         *bool
+			RedirectToHTTPS *bool
+			ListenAddr      *string
+			Port            *int
+			CertFile        *string
+			CertKey         *string
+			LetsEncrypt     struct {
+				Enabled      *bool
+				AcceptTOS    *bool
+				Cache        *string
+				DirectoryURL *string
+				Hosts        []string
+			}
+		}
+		ResponseHeaders map[string]string
+		Stream          struct {
+			PingPeriodSeconds *int
+			AllowedOrigins    []string
+		}
+		Cors struct {
+			AllowOrigins []string
+			AllowMethods []string
+			AllowHeaders []string
+		}
+		TrustedProxies []string
+		SecureCookie   *bool
+	}
+	Database struct {
+		Dialect    *string
+		Connection *string
+	}
+	DefaultUser struct {
+		Name *string
+		Pass *string
+	}
+	PassStrength      *int
+	UploadedImagesDir *string
+	PluginsDir        *string
+	Registration      *bool
+	OIDC              struct {
+		Enabled       *bool
+		Issuer        *string
+		ClientID      *string
+		ClientSecret  *string
+		UsernameClaim *string
+		RedirectURL   *string
+		AutoRegister  *bool
+		Scopes        []string
+	}
+}
+
+func Config(file string) (string, error) {
+	if file == "" {
+		return "", errors.New("migrate-config requires one argument: the path to the old config.yml")
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", fmt.Errorf("cannot read config file %s: %w", file, err)
+	}
+
+	var migrated oldConfig
+	if err := yaml.Unmarshal(data, &migrated); err != nil {
+		return "", fmt.Errorf("cannot parse config file %s: %w", file, err)
+	}
+
+	content, err := godotenv.Marshal(buildEnv(migrated))
+	if err != nil {
+		return "", fmt.Errorf("cannot render config: %w", err)
+	}
+
+	return content, nil
+}
+
+func buildEnv(c oldConfig) map[string]string {
+	out := map[string]string{}
+	str := func(key string, value *string) {
+		if value != nil {
+			out[key] = *value
+		}
+	}
+	num := func(key string, value *int) {
+		if value != nil {
+			out[key] = strconv.Itoa(*value)
+		}
+	}
+	boolean := func(key string, value *bool) {
+		if value != nil {
+			out[key] = strconv.FormatBool(*value)
+		}
+	}
+	list := func(key string, value []string) {
+		if value != nil {
+			out[key] = marshalList(value)
+		}
+	}
+	headers := func(key string, value map[string]string) {
+		if value != nil {
+			out[key] = marshalMap(value)
+		}
+	}
+
+	num(config.EnvServerKeepAlivePeriodSeconds, c.Server.KeepAlivePeriodSeconds)
+	str(config.EnvServerListenAddr, c.Server.ListenAddr)
+	num(config.EnvServerPort, c.Server.Port)
+	boolean(config.EnvServerSSLEnabled, c.Server.SSL.Enabled)
+	boolean(config.EnvServerSSLRedirectToHTTPS, c.Server.SSL.RedirectToHTTPS)
+	str(config.EnvServerSSLListenAddr, c.Server.SSL.ListenAddr)
+	num(config.EnvServerSSLPort, c.Server.SSL.Port)
+	str(config.EnvServerSSLCertFile, c.Server.SSL.CertFile)
+	str(config.EnvServerSSLCertKey, c.Server.SSL.CertKey)
+	boolean(config.EnvServerSSLLetsEncryptEnabled, c.Server.SSL.LetsEncrypt.Enabled)
+	boolean(config.EnvServerSSLLetsEncryptAcceptTOS, c.Server.SSL.LetsEncrypt.AcceptTOS)
+	str(config.EnvServerSSLLetsEncryptCache, c.Server.SSL.LetsEncrypt.Cache)
+	str(config.EnvServerSSLLetsEncryptDirectoryURL, c.Server.SSL.LetsEncrypt.DirectoryURL)
+	list(config.EnvServerSSLLetsEncryptHosts, c.Server.SSL.LetsEncrypt.Hosts)
+	headers(config.EnvServerResponseHeaders, c.Server.ResponseHeaders)
+	num(config.EnvServerStreamPingPeriodSeconds, c.Server.Stream.PingPeriodSeconds)
+	list(config.EnvServerStreamAllowedOrigins, c.Server.Stream.AllowedOrigins)
+	list(config.EnvServerCorsAllowOrigins, c.Server.Cors.AllowOrigins)
+	list(config.EnvServerCorsAllowMethods, c.Server.Cors.AllowMethods)
+	list(config.EnvServerCorsAllowHeaders, c.Server.Cors.AllowHeaders)
+	list(config.EnvServerTrustedProxies, c.Server.TrustedProxies)
+	boolean(config.EnvServerSecureCookie, c.Server.SecureCookie)
+	str(config.EnvDatabaseDialect, c.Database.Dialect)
+	str(config.EnvDatabaseConnection, c.Database.Connection)
+	str(config.EnvDefaultUserName, c.DefaultUser.Name)
+	str(config.EnvDefaultUserPass, c.DefaultUser.Pass)
+	num(config.EnvPassStrength, c.PassStrength)
+	str(config.EnvUploadedImagesDir, c.UploadedImagesDir)
+	str(config.EnvPluginsDir, c.PluginsDir)
+	boolean(config.EnvRegistration, c.Registration)
+	boolean(config.EnvOIDCEnabled, c.OIDC.Enabled)
+	str(config.EnvOIDCIssuer, c.OIDC.Issuer)
+	str(config.EnvOIDCClientID, c.OIDC.ClientID)
+	str(config.EnvOIDCClientSecret, c.OIDC.ClientSecret)
+	str(config.EnvOIDCUsernameClaim, c.OIDC.UsernameClaim)
+	str(config.EnvOIDCRedirectURL, c.OIDC.RedirectURL)
+	boolean(config.EnvOIDCAutoRegister, c.OIDC.AutoRegister)
+	list(config.EnvOIDCScopes, c.OIDC.Scopes)
+	return out
+}
+
+func marshalMap(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func marshalList(values []string) string {
+	var sb strings.Builder
+	writer := csv.NewWriter(&sb)
+	writer.UseCRLF = false
+	if err := writer.Write(values); err != nil {
+		return ""
+	}
+	writer.Flush()
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/config/migrate/migrate_test.go
+++ b/config/migrate/migrate_test.go
@@ -1,0 +1,166 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func runMigrate(t *testing.T, yaml string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yml")
+	assert.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	got, err := Config(path)
+	assert.NoError(t, err)
+	return got
+}
+
+func TestMigrateConfigAllOptions(t *testing.T) {
+	yaml := `
+server:
+  keepaliveperiodseconds: 30
+  listenaddr: 0.0.0.0
+  port: 8080
+  ssl:
+    enabled: true
+    redirecttohttps: false
+    listenaddr: 127.0.0.1
+    port: 8443
+    certfile: /cert.pem
+    certkey: /key.pem
+    letsencrypt:
+      enabled: true
+      accepttos: true
+      cache: /le
+      directoryurl: https://acme.example
+      hosts:
+        - a.tld
+        - b.tld
+  responseheaders:
+    X-Custom: hello
+  stream:
+    pingperiodseconds: 30
+    allowedorigins:
+      - o1
+      - o2
+  cors:
+    alloworigins:
+      - c1
+    allowmethods:
+      - GET
+    allowheaders:
+      - Authorization
+  trustedproxies:
+    - 10.0.0.1
+  securecookie: true
+database:
+  dialect: postgres
+  connection: postgres://localhost/gotify
+defaultuser:
+  name: root
+  pass: secret
+passstrength: 12
+uploadedimagesdir: /images
+pluginsdir: /plugins
+registration: true
+oidc:
+  enabled: true
+  issuer: https://issuer.example
+  clientid: client
+  clientsecret: topsecret
+  usernameclaim: email
+  redirecturl: https://gotify.example/callback
+  autoregister: false
+  scopes:
+    - openid
+    - custom
+`
+	assert.Equal(t, `GOTIFY_DATABASE_CONNECTION="postgres://localhost/gotify"
+GOTIFY_DATABASE_DIALECT="postgres"
+GOTIFY_DEFAULTUSER_NAME="root"
+GOTIFY_DEFAULTUSER_PASS="secret"
+GOTIFY_OIDC_AUTOREGISTER="false"
+GOTIFY_OIDC_CLIENTID="client"
+GOTIFY_OIDC_CLIENTSECRET="topsecret"
+GOTIFY_OIDC_ENABLED="true"
+GOTIFY_OIDC_ISSUER="https://issuer.example"
+GOTIFY_OIDC_REDIRECTURL="https://gotify.example/callback"
+GOTIFY_OIDC_SCOPES="openid,custom"
+GOTIFY_OIDC_USERNAMECLAIM="email"
+GOTIFY_PASSSTRENGTH=12
+GOTIFY_PLUGINSDIR="/plugins"
+GOTIFY_REGISTRATION="true"
+GOTIFY_SERVER_CORS_ALLOWHEADERS="Authorization"
+GOTIFY_SERVER_CORS_ALLOWMETHODS="GET"
+GOTIFY_SERVER_CORS_ALLOWORIGINS="c1"
+GOTIFY_SERVER_KEEPALIVEPERIODSECONDS=30
+GOTIFY_SERVER_LISTENADDR="0.0.0.0"
+GOTIFY_SERVER_PORT=8080
+GOTIFY_SERVER_RESPONSEHEADERS="{\"X-Custom\":\"hello\"}"
+GOTIFY_SERVER_SECURECOOKIE="true"
+GOTIFY_SERVER_SSL_CERTFILE="/cert.pem"
+GOTIFY_SERVER_SSL_CERTKEY="/key.pem"
+GOTIFY_SERVER_SSL_ENABLED="true"
+GOTIFY_SERVER_SSL_LETSENCRYPT_ACCEPTTOS="true"
+GOTIFY_SERVER_SSL_LETSENCRYPT_CACHE="/le"
+GOTIFY_SERVER_SSL_LETSENCRYPT_DIRECTORYURL="https://acme.example"
+GOTIFY_SERVER_SSL_LETSENCRYPT_ENABLED="true"
+GOTIFY_SERVER_SSL_LETSENCRYPT_HOSTS="a.tld,b.tld"
+GOTIFY_SERVER_SSL_LISTENADDR="127.0.0.1"
+GOTIFY_SERVER_SSL_PORT=8443
+GOTIFY_SERVER_SSL_REDIRECTTOHTTPS="false"
+GOTIFY_SERVER_STREAM_ALLOWEDORIGINS="o1,o2"
+GOTIFY_SERVER_STREAM_PINGPERIODSECONDS=30
+GOTIFY_SERVER_TRUSTEDPROXIES="10.0.0.1"
+GOTIFY_UPLOADEDIMAGESDIR="/images"`, runMigrate(t, yaml))
+}
+
+func TestMigrateConfigNoOptions(t *testing.T) {
+	assert.Equal(t, "", runMigrate(t, ""), "an empty config produces no settings")
+}
+
+func TestMigrateConfigOnlyDefaultValues(t *testing.T) {
+	yaml := `server:
+  port: 80
+  ssl:
+    redirecttohttps: true
+database:
+  dialect: sqlite3
+oidc:
+  autoregister: true
+  scopes:
+    - openid
+    - profile
+    - email
+`
+	assert.Equal(t, `GOTIFY_DATABASE_DIALECT="sqlite3"
+GOTIFY_OIDC_AUTOREGISTER="true"
+GOTIFY_OIDC_SCOPES="openid,profile,email"
+GOTIFY_SERVER_PORT=80
+GOTIFY_SERVER_SSL_REDIRECTTOHTTPS="true"`, runMigrate(t, yaml))
+}
+
+func TestMigrateConfigEscapesListEntries(t *testing.T) {
+	yaml := `server:
+  cors:
+    alloworigins:
+      - a,b
+      - 'say "hi"'
+      - c
+`
+	// The CSV-encoded list contains commas and quotes, which godotenv then
+	// double-quotes and escapes.
+	assert.Contains(t, runMigrate(t, yaml),
+		`GOTIFY_SERVER_CORS_ALLOWORIGINS="\"a,b\",\"say \"\"hi\"\"\",c"`)
+}
+
+func TestMigrateConfigErrors(t *testing.T) {
+	_, err := Config("")
+	assert.ErrorContains(t, err, "requires one argument", "no path -> usage error")
+
+	missing := filepath.Join(t.TempDir(), "missing.yml")
+	_, err = Config(missing)
+	assert.ErrorContains(t, err, "cannot read config file", "unreadable file -> error")
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,3 +75,4 @@ EXPOSE $GOTIFY_SERVER_EXPOSE
 COPY --from=builder /target /
 
 ENTRYPOINT ["./gotify-app"]
+CMD ["serve"]

--- a/ui/src/tests/setup.ts
+++ b/ui/src/tests/setup.ts
@@ -123,7 +123,7 @@ const buildGoExecutable = (filename: string): Promise<void> => {
 };
 
 const startGotify = (filename: string, port: number, pluginDir: string): ChildProcess => {
-    const gotify = spawn(filename, [], {
+    const gotify = spawn(filename, ['serve'], {
         env: {
             GOTIFY_SERVER_PORT: '' + port,
             GOTIFY_DATABASE_CONNECTION: 'file::memory:?mode=memory&cache=shared',


### PR DESCRIPTION
This PR:
* Adds a cli with gotify serve, migrate-config, version
* Config migration with the yaml format to env file format
  * I've decided against filtering out default values, because we don't have inheritance anymore, and maybe a user wanted to explicitly set a default value, so that if the default is later changed, their config stays the same.

<details><summary>Migration example</summary>
<p>

```
# Example configuration file for the server.
# Save it to `config.yml` when edited

server:
  keepaliveperiodseconds: 0 # 0 = use Go default (15s); -1 = disable keepalive; set the interval in which keepalive packets will be sent. Only change this value if you know what you are doing.
  listenaddr: 'adrr' # the address to bind on, leave empty to bind on all addresses. Prefix with "unix:" to create a unix socket. Example: "unix:/tmp/gotify.sock".
  port: 80 # the port the HTTP server will listen on

  ssl:
    enabled: false # if https should be enabled
    redirecttohttps: true # redirect to https if site is accessed by http
    listenaddr: 'ddrr' # the address to bind on, leave empty to bind on all addresses. Prefix with "unix:" to create a unix socket. Example: "unix:/tmp/gotify.sock".
    port: 443 # the https port
    certfile: certfile # the cert file (leave empty when using letsencrypt)
    certkey: certkey # the cert key (leave empty when using letsencrypt)
    letsencrypt:
      enabled: false # if the certificate should be requested from letsencrypt
      accepttos: false # if you accept the tos from letsencrypt
      cache: data/certs # the directory of the cache from letsencrypt
      directoryurl: # override the directory url of the ACME server
      hosts: # the hosts for which letsencrypt should request certificates
      - mydomain.tld
      - myotherdomain.tld
  responseheaders: # response headers are added to every response (default: none)
    X-Custom-Header: "custom value"

  trustedproxies: # IPs or IP ranges of trusted proxies. Used to obtain the remote ip via the X-Forwarded-For header. (configure 127.0.0.1 to trust sockets)
  - 127.0.0.1/32
  - ::1
  securecookie: false # If the secure flag should be set on cookies. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#secure

  cors: # Sets cors headers only when needed and provides support for multiple allowed origins. Overrides Access-Control-* Headers in response headers.
    alloworigins:
    - '.+.example.com'
    - 'otherdomain.com'
    allowmethods:
    - "GET"
    - "POST"
    allowheaders:
    - "Authorization"
    - "content-type"
  stream:
    pingperiodseconds: 45 # the interval in which websocket pings will be sent. Only change this value if you know what you are doing.
    allowedorigins: # allowed origins for websocket connections (same origin is always allowed)
    - ".+.example.com"
    - "otherdomain.com"
oidc:
  enabled: false # Enable OpenID Connect login, allowing users to authenticate via an external identity provider (e.g. Keycloak, Authelia, Google).
  issuer: issue # The OIDC issuer URL. This is the base URL of your identity provider, used to discover endpoints. Example: "https://auth.example.com/realms/myrealm"
  clientid: client # The client ID registered with your identity provider for this application.
  clientsecret: secret # The client secret for the registered client.
  redirecturl: http://gotify.example.org/auth/oidc/callback # The callback URL that the identity provider redirects to after authentication. Must match exactly what is configured in your identity provider.
  autoregister: true # If true, automatically create a new user on first OIDC login. If false, only existing users can log in via OIDC.
  usernameclaim: preferred_username # The OIDC claim used to determine the username. Common values: "preferred_username" or "email".

database: # for database see (configure database section)
  dialect: sqlite3
  connection: data/gotify.db
defaultuser: # on database creation, gotify creates an admin user (these values will only be used for the first start, if you want to edit the user after the first start use the WebUI)
  name: admin # the username of the default user
  pass: admin # the password of the default user
passstrength: 10 # the bcrypt password strength (higher = better but also slower)
uploadedimagesdir: data/images # the directory for storing uploaded images
pluginsdir: data/plugins # the directory where plugin resides (leave empty to disable plugins)
registration: false # enable registrations
```

```
$ go run . migrate-config config.example.yml
GOTIFY_DATABASE_CONNECTION="data/gotify.db"
GOTIFY_DATABASE_DIALECT="sqlite3"
GOTIFY_DEFAULTUSER_NAME="admin"
GOTIFY_DEFAULTUSER_PASS="admin"
GOTIFY_OIDC_AUTOREGISTER="true"
GOTIFY_OIDC_CLIENTID="client"
GOTIFY_OIDC_CLIENTSECRET="secret"
GOTIFY_OIDC_ENABLED="false"
GOTIFY_OIDC_ISSUER="issue"
GOTIFY_OIDC_REDIRECTURL="http://gotify.example.org/auth/oidc/callback"
GOTIFY_OIDC_USERNAMECLAIM="preferred_username"
GOTIFY_PASSSTRENGTH=10
GOTIFY_PLUGINSDIR="data/plugins"
GOTIFY_REGISTRATION="false"
GOTIFY_SERVER_CORS_ALLOWHEADERS="Authorization,content-type"
GOTIFY_SERVER_CORS_ALLOWMETHODS="GET,POST"
GOTIFY_SERVER_CORS_ALLOWORIGINS=".+.example.com,otherdomain.com"
GOTIFY_SERVER_KEEPALIVEPERIODSECONDS=0
GOTIFY_SERVER_LISTENADDR="adrr"
GOTIFY_SERVER_PORT=80
GOTIFY_SERVER_RESPONSEHEADERS="{\"X-Custom-Header\":\"custom value\"}"
GOTIFY_SERVER_SECURECOOKIE="false"
GOTIFY_SERVER_SSL_CERTFILE="certfile"
GOTIFY_SERVER_SSL_CERTKEY="certkey"
GOTIFY_SERVER_SSL_ENABLED="false"
GOTIFY_SERVER_SSL_LETSENCRYPT_ACCEPTTOS="false"
GOTIFY_SERVER_SSL_LETSENCRYPT_CACHE="data/certs"
GOTIFY_SERVER_SSL_LETSENCRYPT_ENABLED="false"
GOTIFY_SERVER_SSL_LETSENCRYPT_HOSTS="mydomain.tld,myotherdomain.tld"
GOTIFY_SERVER_SSL_LISTENADDR="ddrr"
GOTIFY_SERVER_SSL_PORT=443
GOTIFY_SERVER_SSL_REDIRECTTOHTTPS="true"
GOTIFY_SERVER_STREAM_ALLOWEDORIGINS=".+.example.com,otherdomain.com"
GOTIFY_SERVER_STREAM_PINGPERIODSECONDS=45
GOTIFY_SERVER_TRUSTEDPROXIES="127.0.0.1/32,::1"
GOTIFY_UPLOADEDIMAGESDIR="data/images"
```

</p>
</details> 