### PR TITLE
fixup! feat(security): application token refresh

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -335,6 +335,11 @@ func (a *ApplicationAPI) UpdateApplicationSecurity(ctx *gin.Context) {
 		if success := successOrAbort(ctx, 500, err); !success {
 			return
 		}
+		if app == nil || app.UserID != auth.GetUserID(ctx) {
+			ctx.AbortWithError(404, fmt.Errorf("app with id %d doesn't exists", id))
+			return
+		}
+
 		action := model.SecurityUpdateAction{}
 		response := model.SecurityUpdateActionResponse{}
 		if err := ctx.Bind(&action); err == nil {

--- a/api/application_test.go
+++ b/api/application_test.go
@@ -187,6 +187,23 @@ func (s *ApplicationSuite) Test_UpdateApplicationSecurity_isNoOpIfNilAction() {
 	assert.Equal(s.T(), oldToken, newToken)
 }
 
+func (s *ApplicationSuite) Test_UpdateApplicationSecurity_expectNotFoundOnCurrentUserIsNotOwner() {
+	s.db.User(2)
+	s.db.User(5).App(1)
+	test.WithUser(s.ctx, 2)
+
+	oldToken, err := s.db.GetApplicationByID(1)
+	assert.NoError(s.T(), err)
+	s.ctx.Request = httptest.NewRequest("PUT", "/application/1/security", bytes.NewBufferString(`{}`))
+	s.ctx.Request.Header.Set("Content-Type", "application/json")
+	s.ctx.Params = gin.Params{{Key: "id", Value: "1"}}
+	s.a.UpdateApplicationSecurity(s.ctx)
+	assert.Equal(s.T(), 404, s.recorder.Code)
+	newToken, err := s.db.GetApplicationByID(1)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), oldToken, newToken)
+}
+
 func (s *ApplicationSuite) Test_DeleteApplication_expectNotFoundOnCurrentUserIsNotOwner() {
 	s.db.User(2)
 	s.db.User(5).App(5)


### PR DESCRIPTION
Sorry I shouldn't have missed this important check. This adds back a missing userid check that prevents users from changing the application token for another.

Credits to @kaimandalic for catching this before release and sending in a report in private. 