### PR TITLE
Fix unsynchronized map write in plugin Manager.RemoveUser

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -192,7 +192,9 @@ func (m *Manager) RemoveUser(userID uint) error {
 				return err
 			}
 		}
+		m.mutex.Lock()
 		delete(m.instances, pluginConf.ID)
+		m.mutex.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`Manager.RemoveUser` (`plugin/manager.go`) deletes from the `m.instances` map without holding `m.mutex`:

```go
if pluginConf.Enabled {
    inst, err := m.Instance(pluginConf.ID)
    ...
    m.mutex.Lock()
    err = inst.Disable()
    m.mutex.Unlock()
    ...
}
delete(m.instances, pluginConf.ID)   // <-- unguarded map write
```

Every other access to `m.instances` is synchronized:
- `Instance()` reads it under `m.mutex.RLock()`.
- The writes in `InitializeForUserID` / `initializeSingleUserPlugin` happen under `m.mutex.Lock()`.

The author even wraps the adjacent `inst.Disable()` in `Lock`/`Unlock` — only this map delete is left unguarded.

## Impact

`RemoveUser` is registered as the `OnUserDeleted` callback (`router.go`: `userChangeNotifier.OnUserDeleted(pluginManager.RemoveUser)`), fired when an admin deletes a user (`DELETE /user/:id`). Concurrently, any authenticated request to the plugin API (`GET /plugin`, `GET/POST /plugin/:id/*`) reads `m.instances` via `Instance()` under `RLock`. An `RLock` reader is **not** protected against a writer that never takes the mutex, so an admin deleting a user (who has plugin configs) while a client polls plugins races the map.

That triggers Go's runtime-fatal **`concurrent map read and map write`** — a fatal error that `gin.Recovery()` cannot recover, crashing the whole server process and dropping all WebSocket streams and in-flight requests.

## Reproduction

A minimal program mirroring the exact pattern (an `RLock`-guarded read in one goroutine vs. an unguarded `delete` in another) reliably fatals:

```
fatal error: concurrent map read and map write
```

## Fix

Take the write lock around the delete, matching every other `m.instances` access:

```go
m.mutex.Lock()
delete(m.instances, pluginConf.ID)
m.mutex.Unlock()
```
