### PR TITLE
fix: don't panic when a Let's Encrypt request fails

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -108,7 +108,14 @@ type LoggingRoundTripper struct {
 
 func (l *LoggingRoundTripper) RoundTrip(r *http.Request) (resp *http.Response, err error) {
 	resp, err = l.RoundTripper.RoundTrip(r)
-	if resp.StatusCode == 429 {
+	if err != nil {
+		log.Warn().
+			Str("client", l.Name).
+			Err(err).
+			Str("method", r.Method).
+			Str("url", r.URL.String()).
+			Msg("Request failed")
+	} else if resp.StatusCode == 429 {
 		log.Warn().
 			Str("client", l.Name).
 			Str("retry_after", resp.Header.Get("Retry-After")).
@@ -122,13 +129,6 @@ func (l *LoggingRoundTripper) RoundTrip(r *http.Request) (resp *http.Response, e
 			Str("method", r.Method).
 			Str("url", r.URL.String()).
 			Msg("Request failed: unexpected status code")
-	} else if err != nil {
-		log.Warn().
-			Str("client", l.Name).
-			Err(err).
-			Str("method", r.Method).
-			Str("url", r.URL.String()).
-			Msg("Request failed")
 	}
 	return resp, err
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -1,0 +1,25 @@
+package runner
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type errRoundTripper struct{ err error }
+
+func (e errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+
+func TestLoggingRoundTripperReturnsTransportError(t *testing.T) {
+	want := errors.New("dial tcp: lookup acme-v02.api.letsencrypt.org: no such host")
+	rt := &LoggingRoundTripper{Name: "Let's Encrypt", RoundTripper: errRoundTripper{err: want}}
+	req, err := http.NewRequest(http.MethodGet, "https://acme-v02.api.letsencrypt.org/directory", nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, want)
+}


### PR DESCRIPTION
A refused connection to the ACME server can take the whole process down, not just the renewal that hit it.

`LoggingRoundTripper.RoundTrip` reads `resp.StatusCode` before it looks at `err`. A dial failure, a DNS miss, a cancelled context or the clients own 60s timeout all come back as a nil response with an error, so that first line panics and the `else if err != nil` branch below it never gets its turn.

Point an `acme.Client` at a directory URL that refuses the connection, through that transport, and you get:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10]

github.com/gotify/server/v3/runner.(*LoggingRoundTripper).RoundTrip
	runner/runner.go:111
```

With the branches swapped it logs the line that branch was written for and hands the error back:

```
{"level":"warn","client":"Let's Encrypt","error":"dial tcp 127.0.0.1:1: connect: connection refused","method":"GET","url":"https://127.0.0.1:1/directory","message":"Request failed"}
```

Which of those you get depends on who made the request. During a handshake `net/http` recovers it, so you lose that connection and a stack trace lands in the log. Renewal is the bad one: autocert schedules it with `time.AfterFunc`, so the callback is a bare goroutine with nothing to recover it, and the server exits.

The diff just moves the error branch to the front, all three log lines are unchaged. There was no test file under `runner/` at all, so theres one now covering the nil-response case.
